### PR TITLE
AMux Bus Adjustments

### DIFF
--- a/cpugraphicsitems.cpp
+++ b/cpugraphicsitems.cpp
@@ -1467,13 +1467,20 @@ void CpuGraphicsItems::repaintAMuxSelect(QPainter *painter)
     color = ok ? Qt::black : Qt::gray;
     painter->setPen(QPen(QBrush(color), 1));
     painter->setBrush(color);
-
-    // AMux Select
-    painter->drawLines(OneByteShapes::AMuxSelect._lines);
-
-    painter->drawImage(QPoint(380,300),
-                       color == Qt::gray ? arrowLeftGray : arrowLeft);
-
+    // Draw AMux select depending on the enabled feature set
+    switch(Pep::cpuFeatures)
+    {
+    case Enu::OneByteDataBus:
+        painter->drawLines(OneByteShapes::AMuxSelect._lines);
+        painter->drawImage(QPoint(380,300),
+                           color == Qt::gray ? arrowLeftGray : arrowLeft);
+        break;
+    case Enu::TwoByteDataBus:
+        painter->drawLines(TwoByteShapes::AMuxSelect._lines);
+        painter->drawImage(TwoByteShapes::AMuxSelect._arrowheads.first(), //Should more arrowheads be added, this will need to be a proper for loop.
+                           color == Qt::gray ? arrowLeftGray : arrowLeft);
+        break;
+    }
     if (ok) {
         switch (aMux) {
         case (0):
@@ -1497,8 +1504,17 @@ void CpuGraphicsItems::repaintAMuxSelect(QPainter *painter)
     painter->setPen(QPen(QBrush(Qt::black), 1));
     painter->setBrush(color);
 
-    // AMux bus
-    painter->drawPolygon(OneByteShapes::AMuxBus);
+    // Draw AMux bus depending on the enabled feature set
+    switch(Pep::cpuFeatures)
+    {
+    case Enu::OneByteDataBus:
+        painter->drawPolygon(OneByteShapes::AMuxBus);
+        break;
+    case Enu::TwoByteDataBus:
+        painter->drawPolygon(TwoByteShapes::AMuxBus);
+        break;
+    }
+
 }
 
 void CpuGraphicsItems::repaintMARMuxSelect(QPainter *painter)

--- a/shapes_one_byte_data_bus.h
+++ b/shapes_one_byte_data_bus.h
@@ -236,8 +236,14 @@ const QPolygon CMuxBus = QPolygon(QVector<QPoint>() << QPoint(290,374)
                                   << QPoint(230,344) << QPoint(280,344)
                                   << QPoint(280,374));
 
-const QPolygon ALUPoly = QPolygon(QVector<QPoint>() << QPoint(314,342)
-                                  << QPoint(366,342) << QPoint(370,353)
+//Use an enumeration for points that other shapes (like AMux) rely on, so that it is easier to re-arrange the diagram.
+enum ALUPolyNumbers
+{
+    ALUUpperLeftLine_LeftPoint = 314,
+    ALUUpperLeftLine_RightPoint=366
+};
+const QPolygon ALUPoly = QPolygon(QVector<QPoint>() << QPoint(ALUUpperLeftLine_LeftPoint,342)
+                                  << QPoint(ALUUpperLeftLine_RightPoint,342) << QPoint(370,353)
                                   << QPoint(390,353) << QPoint(394,342)
                                   << QPoint(447,342) << QPoint(421,394)
                                   << QPoint(340,394));

--- a/shapes_two_byte_data_bus.h
+++ b/shapes_two_byte_data_bus.h
@@ -277,8 +277,8 @@ const QPolygon MARBus = QPolygon(QVector<QPoint>()
 const QPolygon NZVCDataPath = OneByteShapes::NZVCDataPath.translated(controlOffsetX, aluOffsetY);
 
 // AMux, its controls, selection lines, and output.
-const QRect aMuxerDataLabel         = QRect((OneByteShapes::ALUUpperLeftLine_LeftPoint+OneByteShapes::ALUUpperLeftLine_RightPoint)/2,
-                                            //Center AMUX's x on the midpoint of the ALUPolygon
+const QRect aMuxerDataLabel         =  QRect(((controlOffsetX+OneByteShapes::ALUUpperLeftLine_LeftPoint)+(controlOffsetX+OneByteShapes::ALUUpperLeftLine_RightPoint))/2-dataLabelW/2,
+                                            //Center AMUX's x on the midpoint of the ALUPolygon, which ahs been shifter by controlOffsetX pixels.
                                             ALUPoly.boundingRect().y()-AMuxYOffsetFromALUPoly, dataLabelW, dataLabelH);//Place AMuxYOffsetFromALUPoly pixels distance between AMux and the ALU
 
 const QRect aMuxTristateLabel       = QRect(ctrlInputX, aMuxerDataLabel.y(), labelTriW, 21);

--- a/shapes_two_byte_data_bus.h
+++ b/shapes_two_byte_data_bus.h
@@ -77,6 +77,10 @@ enum CommonPositions {
 
 };
 
+//Enumeration that controls the distance between items in the diagram. Hopefully this makes spacing easier to adjust.
+enum CommonOffsets{
+    AMuxYOffsetFromALUPoly=40, //The number of pixels between AMux and the ALU Polygon
+};
 
 // input/label/control section:
 const QRect AddrBus = QRect(40, 151, 20, 600);
@@ -198,11 +202,6 @@ const Arrow EOMuxSelect             = Arrow(QVector<QPoint>() << QPoint(EOMuxerD
                                             << QLine(350, EOMuxTristateLabel.y()+9,
                                                      ctrlInputX - 7, EOMuxTristateLabel.y()+9));
 
-// AMux and its control
-const QRect aMuxerDataLabel         = QRect(306, 400, dataLabelW, dataLabelH);
-const QRect aMuxTristateLabel       = QRect(ctrlInputX, aMuxerDataLabel.y(), labelTriW, 21);
-const QRect aMuxLabel               = QRect(ctrlLabelX, aMuxTristateLabel.y(), labelW, labelH);
-
 // CMux and its control
 const QRect cMuxerLabel             = OneByteShapes::cMuxerLabel.translated(controlOffsetX, aluOffsetY);
 const QRect cMuxTristateLabel       = QRect(ctrlInputX, cMuxerLabel.y()-20, labelTriW, labelTriH);
@@ -253,8 +252,6 @@ const QRect MemReadLabel            = QRect(ctrlLabelX, 731, check2W, check2H);
 const QRect MemReadTristateLabel    = QRect(ctrlInputX, 731, labelTriW, labelTriH);
 
 //const Arrow MDRCk                   = OneByteShapes::MDRCk;
-const Arrow AMuxSelect                = OneByteShapes::AMuxSelect;
-const QPolygon AMuxBus                = OneByteShapes::AMuxBus;
 const QPolygon CMuxBus                = OneByteShapes::CMuxBus.translated(controlOffsetX, aluOffsetY);
 const QPolygon ALUPoly                = OneByteShapes::ALUPoly.translated(controlOffsetX, aluOffsetY);
 const QRect MDRBusOutRect             = OneByteShapes::MDRBusOutRect;
@@ -278,6 +275,31 @@ const QPolygon MARBus = QPolygon(QVector<QPoint>()
                                  << QPoint(combCircX + 30 + 10,177)
                                  << QPoint(combCircX + 30 + 10,151));
 const QPolygon NZVCDataPath = OneByteShapes::NZVCDataPath.translated(controlOffsetX, aluOffsetY);
+
+// AMux, its controls, selection lines, and output.
+const QRect aMuxerDataLabel         = QRect((OneByteShapes::ALUUpperLeftLine_LeftPoint+OneByteShapes::ALUUpperLeftLine_RightPoint)/2,
+                                            //Center AMUX's x on the midpoint of the ALUPolygon
+                                            ALUPoly.boundingRect().y()-AMuxYOffsetFromALUPoly, dataLabelW, dataLabelH);//Place AMuxYOffsetFromALUPoly pixels distance between AMux and the ALU
+
+const QRect aMuxTristateLabel       = QRect(ctrlInputX, aMuxerDataLabel.y(), labelTriW, 21);
+const QRect aMuxLabel               = QRect(ctrlLabelX, aMuxTristateLabel.y(), labelW, labelH);
+const Arrow AMuxSelect              = Arrow(QVector<QPoint>()
+                                            //Place the arrowhead slightly off-centered from AMux, otherwise it is visually odd.
+                                            << QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()+3,aMuxerDataLabel.y()+aMuxerDataLabel.height()/2-2),
+                                            //Draw a line from the aMuxTristateLabel to AMux, and center the line vertically between the two.
+                                            //Add one to the calculated y coordinates, otherwise the line and arrow don't appear to be centered.
+                                            QVector<QLine>()<<QLine(aMuxTristateLabel.x(),aMuxerDataLabel.y()+aMuxerDataLabel.height()/2+1,
+                                                                    //Add 5 to the x coordinate, otherwise the line extends past the arrow.
+                                                                    aMuxerDataLabel.x()+aMuxerDataLabel.width()+5,aMuxerDataLabel.y()+aMuxerDataLabel.height()/2+1));
+const QPolygon AMuxBus              = QPolygon(QVector<QPoint>()
+                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2-5,aMuxerDataLabel.y()+aMuxerDataLabel.height()) //Upper Left Corner
+                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2+5,aMuxerDataLabel.y()+aMuxerDataLabel.height()) //Upper Right Corner
+                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2+5,ALUPoly.boundingRect().y()-(arrowHDepth-5)) //Arrow Inner Right Edge
+                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2+10,ALUPoly.boundingRect().y()-(arrowHDepth-5)) //Arrow Outer Right Edge
+                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2,ALUPoly.boundingRect().y()-arrowHOffset) //Arrow Outer Right Edge
+                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2-10,ALUPoly.boundingRect().y()-(arrowHDepth-5)) //Arrow Outer Left Edge
+                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2-5,ALUPoly.boundingRect().y()-(arrowHDepth-5)) //Arrow Inner Left Edge
+                                               );
 
 // registers
 const QRect RegBank                         = OneByteShapes::RegBank;

--- a/shapes_two_byte_data_bus.h
+++ b/shapes_two_byte_data_bus.h
@@ -278,7 +278,7 @@ const QPolygon NZVCDataPath = OneByteShapes::NZVCDataPath.translated(controlOffs
 
 // AMux, its controls, selection lines, and output.
 const QRect aMuxerDataLabel         =  QRect(((controlOffsetX+OneByteShapes::ALUUpperLeftLine_LeftPoint)+(controlOffsetX+OneByteShapes::ALUUpperLeftLine_RightPoint))/2-dataLabelW/2,
-                                            //Center AMUX's x on the midpoint of the ALUPolygon, which ahs been shifter by controlOffsetX pixels.
+                                            //Center AMUX's x on the midpoint of the ALUPolygon, which has been shifter by controlOffsetX pixels.
                                             ALUPoly.boundingRect().y()-AMuxYOffsetFromALUPoly, dataLabelW, dataLabelH);//Place AMuxYOffsetFromALUPoly pixels distance between AMux and the ALU
 
 const QRect aMuxTristateLabel       = QRect(ctrlInputX, aMuxerDataLabel.y(), labelTriW, 21);


### PR DESCRIPTION
Centered AMux over the ALU Polygon.
Made AMux (+ its controls) and AMuxBus move with the ALU polygon.
Replaced some numeric constants in the ALUPolygon with enumeration equivilants.
Re-arranged the definitions of AMux, as AMux now depends on the definiton of the ALU.
Made AMuxSelect properly aligned with AMux.