### PR TITLE
MDRMuxBuses

### DIFF
--- a/cpugraphicsitems.cpp
+++ b/cpugraphicsitems.cpp
@@ -1263,7 +1263,9 @@ void CpuGraphicsItems::paint(QPainter *painter,
         repaintMDRECk(painter);
         repaintEOMuxSelect(painter);
         repaintMDROSelect(painter);
-        repaintMARMUXToMARBusses(painter);
+        repaintMARMUXToMARBuses(painter);
+        repaintMDRSelect(painter);
+        repaintMDRMuxOutputBuses(painter);
 
         break;
     default:
@@ -1537,7 +1539,6 @@ void CpuGraphicsItems::repaintMARMuxSelect(QPainter *painter)
 void CpuGraphicsItems::repaintMDROSelect(QPainter *painter)
 {
     QColor color;
-
     color = MDROCk->isChecked() ? Qt::black : Qt::gray;
     painter->setPen(QPen(QBrush(color), 1));
     painter->setBrush(color);
@@ -2115,27 +2116,7 @@ void CpuGraphicsItems::repaintMDRMuxSelect(QPainter *painter)
 
         break;
     case Enu::TwoByteDataBus:
-        // MDRMuxOutBus (MDRMux to MDR arrow)
-        painter->drawPolygon(TwoByteShapes::MDREMuxOutBus);
-        painter->drawPolygon(TwoByteShapes::MDROMuxOutBus);
-
-        // finish up by drawing select lines:
-        color = Qt::gray;
-        if (MDREMuxTristateLabel->text() != "") {
-            color = Qt::black;
-        }
-        painter->setPen(color);
-        painter->setBrush(color);
-
-        // MDRMux Select
-        painter->drawLine(257,303, 265,303); painter->drawLine(265,303, 265,324);
-        painter->drawLine(265,324, 279,324); painter->drawLine(291,324, 335,324);
-        painter->drawLine(347,324, 416,324); painter->drawLine(428,324, 543,324);
-
-        painter->drawImage(QPoint(249,300),
-                           color == Qt::gray ? arrowLeftGray : arrowLeft);
-
-
+        //This function is only called from the one byte section of paint(...), so this code will never be used.
         break;
     default:
         break;
@@ -2763,7 +2744,7 @@ void CpuGraphicsItems::repaintMemWriteTwoByteModel(QPainter *painter)
 
 }
 
-void CpuGraphicsItems::repaintMARMUXToMARBusses(QPainter *painter)
+void CpuGraphicsItems::repaintMARMUXToMARBuses(QPainter *painter)
 {
     //Needs conditional painting based on the state of the bus.
     bool marckIsHigh = MARCk->isChecked();
@@ -2778,5 +2759,61 @@ void CpuGraphicsItems::repaintMARMUXToMARBusses(QPainter *painter)
     painter->setBrush(color);
     painter->drawPolygon(TwoByteShapes::MARMuxToMARABus);
     painter->drawPolygon(TwoByteShapes::MARMuxToMARBBus);
+}
+
+void CpuGraphicsItems::repaintMDRSelect(QPainter *painter)
+{
+    //Figure out which control lines are high, and set store the appropriate color to paint the control line
+    bool MDREIsHigh=MDREMuxTristateLabel->text()=="1",MDROIsHigh=MDROMuxTristateLabel->text()=="1";
+    QColor MDREColor=MDREIsHigh?Qt::black:Qt::gray;
+    QColor MDROColor=MDROIsHigh?Qt::black:Qt::gray;
+
+    //Paint MDRESelect's lines and arrow in the appropriate color
+    painter->setPen(MDREColor);
+    painter->drawLines(TwoByteShapes::MDREMuxSelect._lines);
+    painter->drawImage(TwoByteShapes::MDREMuxSelect._arrowheads.first(),
+                       MDREColor == Qt::gray ? arrowLeftGray : arrowLeft);
+
+    //Paint MDROSelect's lines and arrow in the appropriate color
+    painter->setPen(MDROColor);
+    painter->drawLines(TwoByteShapes::MDROMuxSelect._lines);
+    painter->drawImage(TwoByteShapes::MDROMuxSelect._arrowheads.first(),
+                       MDROColor == Qt::gray ? arrowLeftGray : arrowLeft);
+}
+
+void CpuGraphicsItems::repaintMDRMuxOutputBuses(QPainter *painter)
+{
+    // MDRMuxOutBus (MDRMux to MDR arrow)
+    QColor colorMDRE = Qt::white,colorMDRO=Qt::white;
+    // Depending on which input is selected on the MDRMuxes, the color might need to change.
+    // For now red seems to be the most logical color to use all the time.
+    if(MDRECk->isChecked()){
+        colorMDRE=combCircuitRed;
+    }
+    if(MDROCk->isChecked()){
+        colorMDRO=combCircuitRed;
+    }
+    painter->setPen(Qt::black);
+    painter->setBrush(colorMDRE);
+    painter->drawPolygon(TwoByteShapes::MDREMuxOutBus);
+    painter->setBrush(colorMDRO);
+    painter->drawPolygon(TwoByteShapes::MDROMuxOutBus);
+
+    // Selection lines are now handled in a seperate function, but the code originall used to do it is preserved here.
+    //QColor color = Qt::gray;
+    //if (MDREMuxTristateLabel->text() != "") {
+    //    color = Qt::black;
+    //}
+    //painter->setPen(color);
+    //painter->setBrush(color);
+    // MDRMux Select
+    //painter->drawLine(257,303, 265,303); painter->drawLine(265,303, 265,324);
+    //painter->drawLine(265,324, 279,324); painter->drawLine(291,324, 335,324);
+    //painter->drawLine(347,324, 416,324); painter->drawLine(428,324, 543,324);
+
+    /*painter->drawImage(QPoint(249,300),
+                       color == Qt::gray ? arrowLeftGray : arrowLeft);*/
+
+
 }
 

--- a/cpugraphicsitems.cpp
+++ b/cpugraphicsitems.cpp
@@ -1263,8 +1263,8 @@ void CpuGraphicsItems::paint(QPainter *painter,
         repaintMDRECk(painter);
         repaintEOMuxSelect(painter);
         repaintMDROSelect(painter);
+        repaintMDRESelect(painter);
         repaintMARMUXToMARBuses(painter);
-        repaintMDRSelect(painter);
         repaintMDRMuxOutputBuses(painter);
 
         break;
@@ -1538,16 +1538,15 @@ void CpuGraphicsItems::repaintMARMuxSelect(QPainter *painter)
 
 void CpuGraphicsItems::repaintMDROSelect(QPainter *painter)
 {
-    QColor color;
-    color = MDROCk->isChecked() ? Qt::black : Qt::gray;
-    painter->setPen(QPen(QBrush(color), 1));
-    painter->setBrush(color);
+    //Determine if control line is high, so that the color may be set accordingly
+    bool MDROIsHigh=MDROMuxTristateLabel->text()=="1";
+    QColor MDROColor=MDROIsHigh?Qt::black:Qt::gray;
 
-    // MDROdd Select
-    painter->drawLines(TwoByteShapes::MDROSelect._lines);
-    painter->drawImage(TwoByteShapes::MDROSelect._arrowheads.first(),
-                       color == Qt::gray ? arrowDownGray : arrowDown);
-
+    //Paint MDROSelect's lines and arrow in the appropriate color
+    painter->setPen(MDROColor);
+    painter->drawLines(TwoByteShapes::MDROMuxSelect._lines);
+    painter->drawImage(TwoByteShapes::MDROMuxSelect._arrowheads.first(),
+                       MDROColor == Qt::gray ? arrowLeftGray : arrowLeft);
 }
 
 void CpuGraphicsItems::repaintEOMuxSelect(QPainter *painter)
@@ -2454,7 +2453,15 @@ void CpuGraphicsItems::repaintMARCkTwoByteModel(QPainter *painter)
 
 void CpuGraphicsItems::repaintMDROCk(QPainter *painter)
 {
+    QColor color;
+    color = MDROCk->isChecked() ? Qt::black : Qt::gray;
+    painter->setPen(QPen(QBrush(color), 1));
+    painter->setBrush(color);
 
+    // MDROdd Clock
+    painter->drawLines(TwoByteShapes::MDROck._lines);
+    painter->drawImage(TwoByteShapes::MDROck._arrowheads.first(),
+                       color == Qt::gray ? arrowDownGray : arrowDown);
 }
 
 void CpuGraphicsItems::repaintMDRECk(QPainter *painter)
@@ -2761,24 +2768,17 @@ void CpuGraphicsItems::repaintMARMUXToMARBuses(QPainter *painter)
     painter->drawPolygon(TwoByteShapes::MARMuxToMARBBus);
 }
 
-void CpuGraphicsItems::repaintMDRSelect(QPainter *painter)
+void CpuGraphicsItems::repaintMDRESelect(QPainter *painter)
 {
-    //Figure out which control lines are high, and set store the appropriate color to paint the control line
-    bool MDREIsHigh=MDREMuxTristateLabel->text()=="1",MDROIsHigh=MDROMuxTristateLabel->text()=="1";
+    //Determine if control line is high, so that the color may be set accordingly
+    bool MDREIsHigh=MDREMuxTristateLabel->text()=="1";
     QColor MDREColor=MDREIsHigh?Qt::black:Qt::gray;
-    QColor MDROColor=MDROIsHigh?Qt::black:Qt::gray;
 
     //Paint MDRESelect's lines and arrow in the appropriate color
     painter->setPen(MDREColor);
     painter->drawLines(TwoByteShapes::MDREMuxSelect._lines);
     painter->drawImage(TwoByteShapes::MDREMuxSelect._arrowheads.first(),
                        MDREColor == Qt::gray ? arrowLeftGray : arrowLeft);
-
-    //Paint MDROSelect's lines and arrow in the appropriate color
-    painter->setPen(MDROColor);
-    painter->drawLines(TwoByteShapes::MDROMuxSelect._lines);
-    painter->drawImage(TwoByteShapes::MDROMuxSelect._arrowheads.first(),
-                       MDROColor == Qt::gray ? arrowLeftGray : arrowLeft);
 }
 
 void CpuGraphicsItems::repaintMDRMuxOutputBuses(QPainter *painter)

--- a/cpugraphicsitems.h
+++ b/cpugraphicsitems.h
@@ -199,7 +199,9 @@ private:
     void repaintMARMuxSelect(QPainter *painter);
     void repaintMARCkTwoByteModel(QPainter *painter);
 
+    //Currently does nothing (1/21/18)
     void repaintMDROCk(QPainter *painter);
+    //MDROSelect actually repaints MDROCk
     void repaintMDROSelect(QPainter *painter);
     void repaintMDRECk(QPainter *painter);
 
@@ -208,7 +210,9 @@ private:
     void repaintMemReadTwoByteModel(QPainter *painter);
     void repaintMemWriteTwoByteModel(QPainter *painter);
 
-    void repaintMARMUXToMARBusses(QPainter *painter);
+    void repaintMARMUXToMARBuses(QPainter *painter);
+    void repaintMDRSelect(QPainter *painter);
+    void repaintMDRMuxOutputBuses(QPainter *painter);
 
 };
 

--- a/cpugraphicsitems.h
+++ b/cpugraphicsitems.h
@@ -203,6 +203,7 @@ private:
     void repaintMDROCk(QPainter *painter);
     //MDROSelect actually repaints MDROCk
     void repaintMDROSelect(QPainter *painter);
+    void repaintMDRESelect(QPainter *painter);
     void repaintMDRECk(QPainter *painter);
 
     void repaintALUSelectTwoByteModel(QPainter *painter);
@@ -211,7 +212,7 @@ private:
     void repaintMemWriteTwoByteModel(QPainter *painter);
 
     void repaintMARMUXToMARBuses(QPainter *painter);
-    void repaintMDRSelect(QPainter *painter);
+
     void repaintMDRMuxOutputBuses(QPainter *painter);
 
 };

--- a/shapes_two_byte_data_bus.h
+++ b/shapes_two_byte_data_bus.h
@@ -150,19 +150,19 @@ const Arrow MARCk                   = Arrow(QVector<QPoint>() << QPoint(232-40,1
 // MARMux output busses
 const QPolygon MARMuxToMARABus = QPolygon(QVector<QPoint>()  << QPoint(MARMuxerDataLabel.x(), MARALabel.y()+MARALabel.height()/2-5)        //Top Right Corner
                                         << QPoint(MARMuxerDataLabel.x(), MARALabel.y()+MARALabel.height()/2+5)                             //Bottom Right Corner
-                                        << QPoint(MARALabel.x()+MARALabel.width()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2+5)     //Arrow Bottom Left Inner edge
-                                        << QPoint(MARALabel.x()+MARALabel.width()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2+10)    //Arrow Bottom Left Outer Edge
-                                        << QPoint(MARALabel.x()+MARALabel.width()+arrowHOffset, MARALabel.y()+MARALabel.height()/2)        //Arrow Middle Point
-                                        << QPoint(MARALabel.x()+MARALabel.width()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2-10)    //Arrow Top Left Outer Edge
-                                        << QPoint(MARALabel.x()+MARALabel.width()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2-5));   //Arrow Top Left Inner Edge
+                                        << QPoint(MARALabel.right()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2+5)     //Arrow Bottom Left Inner edge
+                                        << QPoint(MARALabel.right()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2+10)    //Arrow Bottom Left Outer Edge
+                                        << QPoint(MARALabel.right()+arrowHOffset, MARALabel.y()+MARALabel.height()/2)        //Arrow Middle Point
+                                        << QPoint(MARALabel.right()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2-10)    //Arrow Top Left Outer Edge
+                                        << QPoint(MARALabel.right()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2-5));   //Arrow Top Left Inner Edge
 
 const QPolygon MARMuxToMARBBus = QPolygon(QVector<QPoint>()  << QPoint(MARMuxerDataLabel.x(), MARBLabel.y()+MARALabel.height()/2-5)        //Top Right Corner
                                         << QPoint(MARMuxerDataLabel.x(), MARBLabel.y()+MARALabel.height()/2+5)                             //Bottom Right Corner
-                                        << QPoint(MARBLabel.x()+MARBLabel.width()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2+5)     //Arrow Bottom Left Inner edge
-                                        << QPoint(MARBLabel.x()+MARBLabel.width()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2+10)    //Arrow Bottom Left Outer Edge
-                                        << QPoint(MARBLabel.x()+MARBLabel.width()+arrowHOffset, MARBLabel.y()+MARALabel.height()/2)        //Arrow Middle Point
-                                        << QPoint(MARBLabel.x()+MARBLabel.width()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2-10)    //Arrow Top Left Outer Edge
-                                        << QPoint(MARBLabel.x()+MARBLabel.width()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2-5));   //Arrow Top Left Inner Edge
+                                        << QPoint(MARBLabel.right()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2+5)     //Arrow Bottom Left Inner edge
+                                        << QPoint(MARBLabel.right()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2+10)    //Arrow Bottom Left Outer Edge
+                                        << QPoint(MARBLabel.right()+arrowHOffset, MARBLabel.y()+MARALabel.height()/2)        //Arrow Middle Point
+                                        << QPoint(MARBLabel.right()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2-10)    //Arrow Top Left Outer Edge
+                                        << QPoint(MARBLabel.right()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2-5));   //Arrow Top Left Inner Edge
 
 // MDROdd, MDROCk and its control
 const QRect MDROLabel               = QRect(combCircX, 254, dataLabelW, dataLabelH);
@@ -180,6 +180,11 @@ const Arrow MDROSelect              = Arrow(QVector<QPoint>() << QPoint(MDROLabe
 const QRect MDROMuxerDataLabel      = QRect(combCircX, 293, dataLabelW, dataLabelH);
 const QRect MDROMuxTristateLabel    = QRect(ctrlInputX, MDROMuxerDataLabel.y()-20, labelTriW, labelTriH);
 const QRect MDROMuxLabel            = QRect(ctrlLabelX, MDROMuxTristateLabel.y(), labelW+20, labelH);
+const Arrow MDROMuxSelect           = Arrow(QVector<QPoint>()
+                                            <<QPoint(MDROMuxerDataLabel.right(),MDROMuxTristateLabel.y()+MDROMuxTristateLabel.height()/2-3),
+                                            QVector<QLine>()
+                                            <<QLine(MDROMuxTristateLabel.x(),MDROMuxTristateLabel.y()+MDROMuxTristateLabel.height()/2,
+                                                    MDROMuxerDataLabel.right()+5,MDROMuxTristateLabel.y()+MDROMuxTristateLabel.height()/2));
 
 // MDREven, MDRECk and its control
 const QRect MDRELabel               = QRect(combCircX, 354, dataLabelW, dataLabelH);
@@ -189,7 +194,11 @@ const QRect MDRECkCheckbox          = QRect(ctrlInputX, MDRELabel.y()-20, checkW
 const QRect MDREMuxerDataLabel      = QRect(combCircX,393, dataLabelW, dataLabelH);
 const QRect MDREMuxTristateLabel    = QRect(ctrlInputX, MDREMuxerDataLabel.y()-20, labelTriW, labelTriH);
 const QRect MDREMuxLabel            = QRect(ctrlLabelX, MDREMuxTristateLabel.y(), labelW+20, labelH);
-
+const Arrow MDREMuxSelect           = Arrow(QVector<QPoint>()
+                                            << QPoint(MDREMuxerDataLabel.right(),MDREMuxTristateLabel.y()+MDREMuxTristateLabel.height()/2-3),
+                                            QVector<QLine>()
+                                            <<QLine(MDREMuxTristateLabel.x(),MDREMuxTristateLabel.y()+MDREMuxTristateLabel.height()/2,
+                                                    MDREMuxerDataLabel.right()+5,MDREMuxTristateLabel.y()+MDREMuxTristateLabel.height()/2));
 // EOMux and its control
 const QRect EOMuxerDataLabel        = QRect(200, 316, dataLabelW, dataLabelH);
 const QRect EOMuxTristateLabel      = QRect(ctrlInputX, EOMuxerDataLabel.y(), labelTriW, labelTriH);
@@ -278,7 +287,7 @@ const QPolygon NZVCDataPath = OneByteShapes::NZVCDataPath.translated(controlOffs
 
 // AMux, its controls, selection lines, and output.
 const QRect aMuxerDataLabel         =  QRect(((controlOffsetX+OneByteShapes::ALUUpperLeftLine_LeftPoint)+(controlOffsetX+OneByteShapes::ALUUpperLeftLine_RightPoint))/2-dataLabelW/2,
-                                            //Center AMUX's x on the midpoint of the ALUPolygon, which has been shifter by controlOffsetX pixels.
+                                            //Center AMUX's x on the midpoint of the ALUPolygon, which has been shifted by controlOffsetX pixels.
                                             ALUPoly.boundingRect().y()-AMuxYOffsetFromALUPoly, dataLabelW, dataLabelH);//Place AMuxYOffsetFromALUPoly pixels distance between AMux and the ALU
 
 const QRect aMuxTristateLabel       = QRect(ctrlInputX, aMuxerDataLabel.y(), labelTriW, 21);
@@ -370,22 +379,22 @@ const QPolygon MDREToDataBus = QPolygon(QVector<QPoint>()  << QPoint(MDROLabel.x
 
 //const QPolygon MDRMuxOutBus;
 const QPolygon MDROMuxOutBus = QPolygon(QVector<QPoint>()
-                                        << QPoint(combCircX + 25 + 05, MDROMuxerDataLabel.y()) // 293
-                                        << QPoint(combCircX + 25 + 05, MDROMuxerDataLabel.y() - 7)
-                                        << QPoint(combCircX + 25 + 00, MDROMuxerDataLabel.y() - 7)
-                                        << QPoint(combCircX + 25 + 10, MDROMuxerDataLabel.y() - 17)
-                                        << QPoint(combCircX + 25 + 20, MDROMuxerDataLabel.y() - 7)
-                                        << QPoint(combCircX + 25 + 15, MDROMuxerDataLabel.y() - 7)
-                                        << QPoint(combCircX + 25 + 15, MDROMuxerDataLabel.y()));
+                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2-5, MDROMuxerDataLabel.y()) //Bottom Left Corner
+                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2-5, MDROMuxerDataLabel.y() - 7) //Arrow Inner Left Edge
+                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2-10, MDROMuxerDataLabel.y() - 7) //Arrow  Outer left Edge
+                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2, MDROMuxerDataLabel.y() - 17) //Arrow Point
+                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2+10, MDROMuxerDataLabel.y() - 7) //Arrow Outer Right Edge
+                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2+5, MDROMuxerDataLabel.y() - 7) //Arrow Inner Right Edge
+                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2+5, MDROMuxerDataLabel.y())); //Bottom Right Corner
 
 const QPolygon MDREMuxOutBus = QPolygon(QVector<QPoint>()
-                                        << QPoint(combCircX + 25 + 05, MDREMuxerDataLabel.y()) // 293
-                                        << QPoint(combCircX + 25 + 05, MDREMuxerDataLabel.y() - 7)
-                                        << QPoint(combCircX + 25 + 00, MDREMuxerDataLabel.y() - 7)
-                                        << QPoint(combCircX + 25 + 10, MDREMuxerDataLabel.y() - 17)
-                                        << QPoint(combCircX + 25 + 20, MDREMuxerDataLabel.y() - 7)
-                                        << QPoint(combCircX + 25 + 15, MDREMuxerDataLabel.y() - 7)
-                                        << QPoint(combCircX + 25 + 15, MDREMuxerDataLabel.y()));
+                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2-5, MDREMuxerDataLabel.y()) //Bottom Left Corner
+                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2-5, MDREMuxerDataLabel.y() - 7) //Arrow Inner Left Edge
+                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2-10, MDREMuxerDataLabel.y() - 7) //Arrow  Outer left Edge
+                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2, MDREMuxerDataLabel.y() - 17) //Arrow Point
+                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2+10, MDREMuxerDataLabel.y() - 7) //Arrow Outer Right Edge
+                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2+5, MDREMuxerDataLabel.y() - 7) //Arrow Inner Right Edge
+                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2+5, MDREMuxerDataLabel.y())); //Bottom Right Corner
 
 
 

--- a/shapes_two_byte_data_bus.h
+++ b/shapes_two_byte_data_bus.h
@@ -167,7 +167,7 @@ const QPolygon MARMuxToMARBBus = QPolygon(QVector<QPoint>()  << QPoint(MARMuxerD
 // MDROdd, MDROCk and its control
 const QRect MDROLabel               = QRect(combCircX, 254, dataLabelW, dataLabelH);
 const QRect MDROCkCheckbox          = QRect(ctrlInputX, MDROLabel.y()-20, checkW+10, checkH);
-const Arrow MDROSelect              = Arrow(QVector<QPoint>() << QPoint(MDROLabel.x()+MDROLabel.width()/2, MDROLabel.y()-12),
+const Arrow MDROck              = Arrow(QVector<QPoint>() << QPoint(MDROLabel.x()+MDROLabel.width()/2, MDROLabel.y()-12),
                                             QVector<QLine>()
                                             << QLine(MDROLabel.x()+MDROLabel.width()/2+3, MDROLabel.y()-4,
                                                      MDROLabel.x()+MDROLabel.width()/2+3, MDROLabel.y()-19)


### PR DESCRIPTION
Changed spelling of busses -> buses in several locations.
Removed Two Byte specific code from repaintMDRMuxSelect, since that function was only called from one byte sections of code.
Created MDRMux selection lines and output buses, and the necessary functions to paint them.
Simplified some alignment math from previous commits.