### PR TITLE
EOMux Alignment Changes

### DIFF
--- a/cpugraphicsitems.cpp
+++ b/cpugraphicsitems.cpp
@@ -1262,6 +1262,7 @@ void CpuGraphicsItems::paint(QPainter *painter,
         repaintMDROCk(painter);
         repaintMDRECk(painter);
         repaintEOMuxSelect(painter);
+        repaintEOMuxOutpusBus(painter);
         repaintMDROSelect(painter);
         repaintMDRESelect(painter);
         repaintMARMUXToMARBuses(painter);
@@ -1806,10 +1807,21 @@ void CpuGraphicsItems::repaintSBitOut(QPainter *painter)
     painter->setPen(QPen(QBrush(color), 1));
     painter->setBrush(color);
 
-    // line from S bit to CSMux
-    painter->drawLines(OneByteShapes::SBitToCSMux._lines);
-    // arrow:
-    painter->drawImage(OneByteShapes::SBitToCSMux._arrowheads.first(), arrowUp);
+    switch(Pep::cpuFeatures)
+    {
+    case Enu::OneByteDataBus:
+        // line from S bit to CSMux
+        painter->drawLines(OneByteShapes::SBitToCSMux._lines);
+        // arrow:
+        painter->drawImage(OneByteShapes::SBitToCSMux._arrowheads.first(), arrowUp);
+        break;
+    case Enu::TwoByteDataBus:
+        // line from S bit to CSMux
+        painter->drawLines(TwoByteShapes::SBitToCSMux._lines);
+        // arrow:
+        painter->drawImage(TwoByteShapes::SBitToCSMux._arrowheads.first(), arrowUp);
+        break;
+    }
 }
 
 void CpuGraphicsItems::repaintCBitOut(QPainter *painter)
@@ -2442,12 +2454,12 @@ void CpuGraphicsItems::repaintMARCkTwoByteModel(QPainter *painter)
     // MARCk
     painter->drawLines(TwoByteShapes::MARCk._lines);
 
-    painter->drawEllipse(QPoint(235-40,177), 2, 2);
 
-    painter->drawImage(QPoint(232-40,155),
-                       color == Qt::gray ? arrowUpGray : arrowUp);
-    painter->drawImage(QPoint(232-40,191),
-                       color == Qt::gray ? arrowDownGray : arrowDown);
+    painter->drawEllipse(QPoint(TwoByteShapes::MARCk._lines.last().x1(),177), 2, 2);
+    painter->drawImage(TwoByteShapes::MARCk._arrowheads[0],
+            color == Qt::gray ? arrowUpGray : arrowUp);
+    painter->drawImage(TwoByteShapes::MARCk._arrowheads[1],
+            color == Qt::gray ? arrowDownGray : arrowDown);
 }
 
 
@@ -2488,6 +2500,14 @@ void CpuGraphicsItems::repaintMDRECk(QPainter *painter)
 //        break;
 //    }
 
+}
+
+void CpuGraphicsItems::repaintEOMuxOutpusBus(QPainter *painter)
+{
+    QColor color = Qt::white;
+    painter->setPen(Qt::black);
+    painter->setBrush(color);
+    painter->drawPolygon(TwoByteShapes::EOMuxOutputBus);
 }
 
 void CpuGraphicsItems::repaintALUSelectTwoByteModel(QPainter *painter)

--- a/cpugraphicsitems.cpp
+++ b/cpugraphicsitems.cpp
@@ -2681,15 +2681,15 @@ void CpuGraphicsItems::repaintMemWriteTwoByteModel(QPainter *painter)
                        color == Qt::gray ? arrowLeftGray : arrowLeft);
 
     // draw line from memWrite to MDRO out:
-    painter->drawEllipse(QPoint(TwoByteShapes::DataBus.right()+25,
+    painter->drawEllipse(QPoint(TwoByteShapes::DataBus.right()+20,
                                 TwoByteShapes::MemWriteSelect.y1()),
                          2, 2);
-    painter->drawLine(TwoByteShapes::DataBus.right()+25,719, TwoByteShapes::DataBus.right()+25,345); //611+8
+    painter->drawLine(TwoByteShapes::DataBus.right()+20,719, TwoByteShapes::DataBus.right()+20,345); //611+8
     // memWrite line from the label to the bus:
-    painter->drawLine(TwoByteShapes::DataBus.right()+25,333, TwoByteShapes::DataBus.right()+25,280); //268+12
-    painter->drawImage(QPoint(TwoByteShapes::DataBus.right()+22,271), //96-3 //268+12-9
+    painter->drawLine(TwoByteShapes::DataBus.right()+20,333, TwoByteShapes::DataBus.right()+20,280); //268+12
+    painter->drawImage(QPoint(TwoByteShapes::DataBus.right()+17,271), //96-3 //268+12-9
                        color == Qt::gray ? arrowUpGray : arrowUp);
-    painter->drawImage(QPoint(TwoByteShapes::DataBus.right()+22,371), //96-3 //268+12-9
+    painter->drawImage(QPoint(TwoByteShapes::DataBus.right()+17,371), //96-3 //268+12-9
                        color == Qt::gray ? arrowUpGray : arrowUp);
 
     // repaint the MDR-to-main-bus line, based on if MemWrite is set or not
@@ -2799,6 +2799,12 @@ void CpuGraphicsItems::repaintMDRESelect(QPainter *painter)
     painter->drawLines(TwoByteShapes::MDREMuxSelect._lines);
     painter->drawImage(TwoByteShapes::MDREMuxSelect._arrowheads.first(),
                        MDREColor == Qt::gray ? arrowLeftGray : arrowLeft);
+    if(MDREIsHigh){
+        MDREMuxerDataLabel->setPalette(QPalette(combCircuitGreen));
+    }
+    else{
+        MDREMuxerDataLabel->setPalette(QPalette(Qt::white));
+    }
 }
 
 void CpuGraphicsItems::repaintMDRMuxOutputBuses(QPainter *painter)
@@ -2807,11 +2813,12 @@ void CpuGraphicsItems::repaintMDRMuxOutputBuses(QPainter *painter)
     QColor colorMDRE = Qt::white,colorMDRO=Qt::white;
     // Depending on which input is selected on the MDRMuxes, the color might need to change.
     // For now red seems to be the most logical color to use all the time.
-    if(MDRECk->isChecked()){
-        colorMDRE=combCircuitRed;
+    QString MDREText =MDREMuxTristateLabel->text(), MDROText=MDROMuxTristateLabel->text();
+    if(MDRECk->isChecked()&&(MDREText=="1"||MDREText=="0")){
+        colorMDRE=combCircuitGreen.lighter(120);
     }
-    if(MDROCk->isChecked()){
-        colorMDRO=combCircuitRed;
+    if(MDROCk->isChecked()&&(MDROText=="1"||MDROText=="0")){
+        colorMDRO=combCircuitGreen.lighter(120);
     }
     painter->setPen(Qt::black);
     painter->setBrush(colorMDRE);

--- a/cpugraphicsitems.h
+++ b/cpugraphicsitems.h
@@ -205,6 +205,7 @@ private:
     void repaintMDROSelect(QPainter *painter);
     void repaintMDRESelect(QPainter *painter);
     void repaintMDRECk(QPainter *painter);
+    void repaintEOMuxOutpusBus(QPainter *painter);
 
     void repaintALUSelectTwoByteModel(QPainter *painter);
 

--- a/shapes_one_byte_data_bus.h
+++ b/shapes_one_byte_data_bus.h
@@ -240,13 +240,14 @@ const QPolygon CMuxBus = QPolygon(QVector<QPoint>() << QPoint(290,374)
 enum ALUPolyNumbers
 {
     ALUUpperLeftLine_LeftPoint = 314,
-    ALUUpperLeftLine_RightPoint=366
+    ALUUpperLeftLine_RightPoint=366,
+    ALUBottomBound=394,
 };
 const QPolygon ALUPoly = QPolygon(QVector<QPoint>() << QPoint(ALUUpperLeftLine_LeftPoint,342)
                                   << QPoint(ALUUpperLeftLine_RightPoint,342) << QPoint(370,353)
                                   << QPoint(390,353) << QPoint(394,342)
-                                  << QPoint(447,342) << QPoint(421,394)
-                                  << QPoint(340,394));
+                                  << QPoint(447,342) << QPoint(421,ALUBottomBound)
+                                  << QPoint(340,ALUBottomBound));
 
 // the two shapes that make up the arrow out to the right of the MDR
 const QRect MDRBusOutRect = QRect(244, 258, 36, 10);

--- a/shapes_two_byte_data_bus.h
+++ b/shapes_two_byte_data_bus.h
@@ -72,14 +72,17 @@ enum CommonPositions {
     ctrlLabelX = 579 + controlOffsetX,
     ctrlInputX = 550 + controlOffsetX,
     interfaceRegsX = 175,               // x-center of MARB, MARA, ...
-    combCircX = interfaceRegsX - iRegXOffset,
+    combCircX = interfaceRegsX - iRegXOffset-20, //Combinational circuits need to be moved further left to fit.
+    combCircY = 132, //Memory Combinational circuits start at this height
     statusBitsX = 526,//476,
 
 };
 
-//Enumeration that controls the distance between items in the diagram. Hopefully this makes spacing easier to adjust.
+//Enumeration that controls the distance between certain items in the diagram. Hopefully this makes spacing easier to adjust.
 enum CommonOffsets{
-    AMuxYOffsetFromALUPoly=40, //The number of pixels between AMux and the ALU Polygon
+    AMuxYOffsetFromALUPoly=40,  //The number of pixels between AMux and the ALU Polygon
+    MARMUXOffestFromMARA=25,    //Number of pixels between MARMux and (MARA, MARB) horizontally.
+    MARAOffsetFromMARB=70,      //Number of pixels vertically between MARA and MARB
 };
 
 // input/label/control section:
@@ -124,7 +127,7 @@ const Arrow ASelect                 = Arrow(QVector<QPoint>() << QPoint(499, 91)
                                                      533, aLabel.y() + selectYOffset + selectSlashOffset));
 
 // MARMux and its control
-const QRect MARMuxerDataLabel       = QRect(230, 132, 89, 89); // 89 x 89 square from bottom of MARA to top of MARB
+const QRect MARMuxerDataLabel       = QRect((combCircX+dataLabelW)+MARMUXOffestFromMARA, combCircY, 89, 89); // 89 x 89 square from bottom of MARA to top of MARB
 const QRect MARMuxTristateLabel     = QRect(ctrlInputX, MARMuxerDataLabel.y()-28, labelTriW, labelTriH);
 const QRect MARMuxLabel             = QRect(ctrlLabelX, MARMuxTristateLabel.y(), labelW+20, labelH);
 const Arrow MARMuxSelect            = Arrow(QVector<QPoint>() << QPoint(MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2, MARMuxerDataLabel.y()-12),
@@ -138,26 +141,33 @@ const Arrow MARMuxSelect            = Arrow(QVector<QPoint>() << QPoint(MARMuxer
 
 // MARCk and its control
 const QRect MARCkCheckbox           = QRect(ctrlInputX, 169, check2W, check2H);
-const QRect MARALabel               = QRect(combCircX, 202, dataLabelW, dataLabelH); // MARA register
-const QRect MARBLabel               = QRect(combCircX, 132, dataLabelW, dataLabelH); // MARB register
-const Arrow MARCk                   = Arrow(QVector<QPoint>() << QPoint(232-40,155) << QPoint(232-40,191), // What does this do?
+const QRect MARALabel               = QRect(combCircX, combCircY+MARAOffsetFromMARB, dataLabelW, dataLabelH); // MARA register.
+const QRect MARBLabel               = QRect(combCircX, combCircY, dataLabelW, dataLabelH); // MARB register
+const Arrow MARCk                   = Arrow(QVector<QPoint>()
+                                            //The Arrows intersecting MAR,MARB should be roughly 5/7 of the way down the circuits.
+                                            << QPoint(combCircX+5*dataLabelW/7+7,combCircY+dataLabelH+3)
+                                            << QPoint(combCircX+5*dataLabelW/7+7,combCircY+MARAOffsetFromMARB-11),
                                             QVector<QLine> ()
                                             << QLine(428,177, 543,177)
                                             << QLine(367,177, 416,177)
                                             << QLine(291,177, 355,177)
                                             << QLine(235-50,177, 279,177)
-                                            << QLine(235-50,163, 235-50,191));  //Vertical line at left end of MARck
+                                            //The vertical lines intersecting MAR,MARB should be roughly 5/7 of the way down the circuits.
+                                            << QLine(combCircX+5*dataLabelW/7+10,combCircY+dataLabelH+3,
+                                                     combCircX+5*dataLabelW/7+10,combCircY+MARAOffsetFromMARB-3));  //Vertical line at left end of MARck
 // MARMux output busses
-const QPolygon MARMuxToMARABus = QPolygon(QVector<QPoint>()  << QPoint(MARMuxerDataLabel.x(), MARALabel.y()+MARALabel.height()/2-5)        //Top Right Corner
-                                        << QPoint(MARMuxerDataLabel.x(), MARALabel.y()+MARALabel.height()/2+5)                             //Bottom Right Corner
+const QPolygon MARMuxToMARABus = QPolygon(QVector<QPoint>()
+                                        << QPoint(MARMuxerDataLabel.x(), MARALabel.y()+MARALabel.height()/2-5)               //Top Right Corner
+                                        << QPoint(MARMuxerDataLabel.x(), MARALabel.y()+MARALabel.height()/2+5)               //Bottom Right Corner
                                         << QPoint(MARALabel.right()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2+5)     //Arrow Bottom Left Inner edge
                                         << QPoint(MARALabel.right()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2+10)    //Arrow Bottom Left Outer Edge
                                         << QPoint(MARALabel.right()+arrowHOffset, MARALabel.y()+MARALabel.height()/2)        //Arrow Middle Point
                                         << QPoint(MARALabel.right()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2-10)    //Arrow Top Left Outer Edge
                                         << QPoint(MARALabel.right()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2-5));   //Arrow Top Left Inner Edge
 
-const QPolygon MARMuxToMARBBus = QPolygon(QVector<QPoint>()  << QPoint(MARMuxerDataLabel.x(), MARBLabel.y()+MARALabel.height()/2-5)        //Top Right Corner
-                                        << QPoint(MARMuxerDataLabel.x(), MARBLabel.y()+MARALabel.height()/2+5)                             //Bottom Right Corner
+const QPolygon MARMuxToMARBBus = QPolygon(QVector<QPoint>()
+                                        << QPoint(MARMuxerDataLabel.x(), MARBLabel.y()+MARALabel.height()/2-5)               //Top Right Corner
+                                        << QPoint(MARMuxerDataLabel.x(), MARBLabel.y()+MARALabel.height()/2+5)               //Bottom Right Corner
                                         << QPoint(MARBLabel.right()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2+5)     //Arrow Bottom Left Inner edge
                                         << QPoint(MARBLabel.right()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2+10)    //Arrow Bottom Left Outer Edge
                                         << QPoint(MARBLabel.right()+arrowHOffset, MARBLabel.y()+MARALabel.height()/2)        //Arrow Middle Point
@@ -200,7 +210,8 @@ const Arrow MDREMuxSelect           = Arrow(QVector<QPoint>()
                                             <<QLine(MDREMuxTristateLabel.x(),MDREMuxTristateLabel.y()+MDREMuxTristateLabel.height()/2,
                                                     MDREMuxerDataLabel.right()+5,MDREMuxTristateLabel.y()+MDREMuxTristateLabel.height()/2));
 // EOMux and its control
-const QRect EOMuxerDataLabel        = QRect(200, 316, dataLabelW, dataLabelH);
+const QRect EOMuxerDataLabel        = QRect(MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2-dataLabelW/2, //Center EOMux horizontally on MARMux
+                                            MDRELabel.bottom()-20, dataLabelW, dataLabelH); //Temporary Y value, until the ALU is moved down.
 const QRect EOMuxTristateLabel      = QRect(ctrlInputX, EOMuxerDataLabel.y(), labelTriW, labelTriH);
 const QRect EOMuxLabel              = QRect(ctrlLabelX, EOMuxTristateLabel.y(), labelW, labelH);
 const Arrow EOMuxSelect             = Arrow(QVector<QPoint>() << QPoint(EOMuxerDataLabel.right()+4,
@@ -300,6 +311,25 @@ const Arrow AMuxSelect              = Arrow(QVector<QPoint>()
                                             QVector<QLine>()<<QLine(aMuxTristateLabel.x(),aMuxerDataLabel.y()+aMuxerDataLabel.height()/2+1,
                                                                     //Add 5 to the x coordinate, otherwise the line extends past the arrow.
                                                                     aMuxerDataLabel.x()+aMuxerDataLabel.width()+5,aMuxerDataLabel.y()+aMuxerDataLabel.height()/2+1));
+
+//EOMux bus definition is split from EOMux, because it depends on AMUX, which depends on the ALU
+const QPolygon EOMuxOutputBus          = QPolygon(QVector<QPoint>()
+                                            //Foot
+                                            <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2-5,EOMuxerDataLabel.bottom()+1) //Top Left point
+                                            <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2+5,EOMuxerDataLabel.bottom()+1) //Top Right point
+                                            <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2+5,EOMuxerDataLabel.bottom()+5) //Point between upper right vertical leg, and upper horizontal leg
+                                            <<QPoint(aMuxerDataLabel.x()+15,EOMuxerDataLabel.bottom()+5) //Point between upper horizontal leg, and the right vertical leg
+                                            //Arrow
+                                            <<QPoint(aMuxerDataLabel.x()+15,aMuxerDataLabel.y()-(arrowHDepth-5)) //Arrow inner right point
+                                            <<QPoint(aMuxerDataLabel.x()+20,aMuxerDataLabel.y()-(arrowHDepth-5)) //Arrow outer right point
+                                            <<QPoint(aMuxerDataLabel.x()+10,aMuxerDataLabel.y()-arrowHOffset) //Arrow middle  point
+                                            <<QPoint(aMuxerDataLabel.x(),aMuxerDataLabel.y()-(arrowHDepth-5)) //Arrow outer left point
+                                            <<QPoint(aMuxerDataLabel.x()+5 ,aMuxerDataLabel.y()-(arrowHDepth-5)) //Arrow inner left point
+                                            //Remainder of Foot
+                                            <<QPoint(aMuxerDataLabel.x()+5,EOMuxerDataLabel.bottom()+15) //Point between arrow left side and lower horizontal leg
+                                            <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2-5,EOMuxerDataLabel.bottom()+15) //Point between lower horizontal leg and start
+                                            );
+
 const QPolygon AMuxBus              = QPolygon(QVector<QPoint>()
                                                <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2-5,aMuxerDataLabel.y()+aMuxerDataLabel.height()) //Upper Left Corner
                                                <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2+5,aMuxerDataLabel.y()+aMuxerDataLabel.height()) //Upper Right Corner

--- a/shapes_two_byte_data_bus.h
+++ b/shapes_two_byte_data_bus.h
@@ -83,7 +83,17 @@ enum CommonOffsets{
     AMuxYOffsetFromALUPoly=40,  //The number of pixels between AMux and the ALU Polygon
     MARMUXOffestFromMARA=25,    //Number of pixels between MARMux and (MARA, MARB) horizontally.
     MARAOffsetFromMARB=70,      //Number of pixels vertically between MARA and MARB
-};
+    MDREOffsetFromCombY=120,    //Number of pixels vertically between MDRO register and the combCircY origin.
+    MDRORegOffsetFromMDREMux=42,//Number of pixels vertically between MDROMux and MDREMux
+    MDRRegOffsetFromMDRMux=20,  //Number of pixels between the bottom of MDRO,MDRE registers and the top of MDROMux, MDREMux
+    SCKYOffsetFromALU=43,       //Number of pixel between bottom of ALU and top of SCk controls
+    CCkYOffsetFromALU=70,       //Bottom of ALU and top of CCk
+    VCkYOffsetFromALU=97,       //Bottom of ALU and top of VCk
+    ANDZYOffsetFromALU=123,     //Bottom of ALU and top of ANDZ
+    ZCkYOffsetFromALU=150,      //Bottom of ALU and top of ZCk
+    NCkYOffsetFromALU=192,      //Bottom of ALU and top of NCk
+
+  };
 
 // input/label/control section:
 const QRect AddrBus = QRect(40, 151, 20, 600);
@@ -127,7 +137,7 @@ const Arrow ASelect                 = Arrow(QVector<QPoint>() << QPoint(499, 91)
                                                      533, aLabel.y() + selectYOffset + selectSlashOffset));
 
 // MARMux and its control
-const QRect MARMuxerDataLabel       = QRect((combCircX+dataLabelW)+MARMUXOffestFromMARA, combCircY, 89, 89); // 89 x 89 square from bottom of MARA to top of MARB
+const QRect MARMuxerDataLabel       = QRect((combCircX+dataLabelW)+MARMUXOffestFromMARA, combCircY, dataLabelH+MARAOffsetFromMARB, dataLabelH+MARAOffsetFromMARB); // 89 x 89 square from bottom of MARA to top of MARB
 const QRect MARMuxTristateLabel     = QRect(ctrlInputX, MARMuxerDataLabel.y()-28, labelTriW, labelTriH);
 const QRect MARMuxLabel             = QRect(ctrlLabelX, MARMuxTristateLabel.y(), labelW+20, labelH);
 const Arrow MARMuxSelect            = Arrow(QVector<QPoint>() << QPoint(MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2, MARMuxerDataLabel.y()-12),
@@ -175,7 +185,7 @@ const QPolygon MARMuxToMARBBus = QPolygon(QVector<QPoint>()
                                         << QPoint(MARBLabel.right()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2-5));   //Arrow Top Left Inner Edge
 
 // MDROdd, MDROCk and its control
-const QRect MDROLabel               = QRect(combCircX, 254, dataLabelW, dataLabelH);
+const QRect MDROLabel               = QRect(combCircX, combCircY+MDREOffsetFromCombY, dataLabelW, dataLabelH);
 const QRect MDROCkCheckbox          = QRect(ctrlInputX, MDROLabel.y()-20, checkW+10, checkH);
 const Arrow MDROck              = Arrow(QVector<QPoint>() << QPoint(MDROLabel.x()+MDROLabel.width()/2, MDROLabel.y()-12),
                                             QVector<QLine>()
@@ -187,7 +197,7 @@ const Arrow MDROck              = Arrow(QVector<QPoint>() << QPoint(MDROLabel.x(
                                                      ctrlInputX - 7, MDROCkCheckbox.y()+9));
 
 // MDROMux and its control
-const QRect MDROMuxerDataLabel      = QRect(combCircX, 293, dataLabelW, dataLabelH);
+const QRect MDROMuxerDataLabel      = QRect(combCircX, MDROLabel.bottom()+MDRRegOffsetFromMDRMux, dataLabelW, dataLabelH);
 const QRect MDROMuxTristateLabel    = QRect(ctrlInputX, MDROMuxerDataLabel.y()-20, labelTriW, labelTriH);
 const QRect MDROMuxLabel            = QRect(ctrlLabelX, MDROMuxTristateLabel.y(), labelW+20, labelH);
 const Arrow MDROMuxSelect           = Arrow(QVector<QPoint>()
@@ -197,11 +207,11 @@ const Arrow MDROMuxSelect           = Arrow(QVector<QPoint>()
                                                     MDROMuxerDataLabel.right()+5,MDROMuxTristateLabel.y()+MDROMuxTristateLabel.height()/2));
 
 // MDREven, MDRECk and its control
-const QRect MDRELabel               = QRect(combCircX, 354, dataLabelW, dataLabelH);
+const QRect MDRELabel               = QRect(combCircX, MDROMuxerDataLabel.bottom()+MDRORegOffsetFromMDREMux, dataLabelW, dataLabelH);
 const QRect MDRECkCheckbox          = QRect(ctrlInputX, MDRELabel.y()-20, checkW+10, checkH);
 
 // MDREMux and its control
-const QRect MDREMuxerDataLabel      = QRect(combCircX,393, dataLabelW, dataLabelH);
+const QRect MDREMuxerDataLabel      = QRect(combCircX,MDRELabel.bottom()+MDRRegOffsetFromMDRMux, dataLabelW, dataLabelH);
 const QRect MDREMuxTristateLabel    = QRect(ctrlInputX, MDREMuxerDataLabel.y()-20, labelTriW, labelTriH);
 const QRect MDREMuxLabel            = QRect(ctrlLabelX, MDREMuxTristateLabel.y(), labelW+20, labelH);
 const Arrow MDREMuxSelect           = Arrow(QVector<QPoint>()
@@ -234,34 +244,34 @@ const QRect ALULabel                = QRect(ctrlLabelX,  470, 31,     labelH);
 const QRect ALUFunctionLabel        = OneByteShapes::ALUFunctionLabel.translated(controlOffsetX,
                                                                                  aluOffsetY);
 // CSMux and its control
-const QRect CSMuxLabel              = QRect(ctrlLabelX,  499, labelW, labelH);
-const QRect CSMuxerDataLabel        = QRect(statusBitsX+19-69, 499, dataLabelW, dataLabelH);
-const QRect CSMuxTristateLabel      = QRect(ctrlInputX,  499, 25,     21);
+const QRect CSMuxLabel              = QRect(ctrlLabelX,  OneByteShapes::ALUBottomBound+aluOffsetY+5, labelW, labelH);
+const QRect CSMuxerDataLabel        = QRect(statusBitsX+19-69, OneByteShapes::ALUBottomBound+aluOffsetY+5, dataLabelW, dataLabelH);
+const QRect CSMuxTristateLabel      = QRect(ctrlInputX,  OneByteShapes::ALUBottomBound+aluOffsetY+5, 25,     21);
 
 // Status bit S, SCk and its control
-const QRect SCkCheckBox             = QRect(ctrlInputX,  537, checkW, checkH);
-const QRect sBitLabel               = QRect(statusBitsX, 537, 19,     dataLabelH);
+const QRect SCkCheckBox             = QRect(ctrlInputX,  OneByteShapes::ALUBottomBound+aluOffsetY+SCKYOffsetFromALU, checkW, checkH);
+const QRect sBitLabel               = QRect(statusBitsX, OneByteShapes::ALUBottomBound+aluOffsetY+SCKYOffsetFromALU, 19,     dataLabelH);
 
 // Status bit C, CCk and its control
-const QRect CCkCheckBox             = QRect(ctrlInputX,  564, checkW, checkH);
-const QRect cBitLabel               = QRect(statusBitsX, 563, 19,     dataLabelH);
+const QRect CCkCheckBox             = QRect(ctrlInputX,  OneByteShapes::ALUBottomBound+aluOffsetY+CCkYOffsetFromALU, checkW, checkH);
+const QRect cBitLabel               = QRect(statusBitsX, OneByteShapes::ALUBottomBound+aluOffsetY+CCkYOffsetFromALU -1, 19,     dataLabelH);
 
 // Status bit V, VCk and its control
-const QRect VCkCheckBox             = QRect(ctrlInputX,  591, checkW, checkH);
-const QRect vBitLabel               = QRect(statusBitsX, 591, 19,     dataLabelH);
+const QRect VCkCheckBox             = QRect(ctrlInputX,  OneByteShapes::ALUBottomBound+aluOffsetY+VCkYOffsetFromALU, checkW, checkH);
+const QRect vBitLabel               = QRect(statusBitsX, OneByteShapes::ALUBottomBound+aluOffsetY+VCkYOffsetFromALU, 19,     dataLabelH);
 
 // AndZ and its control
-const QRect AndZLabel               = QRect(ctrlLabelX,  617, 45,     20);
-const QRect AndZTristateLabel       = QRect(ctrlInputX, 617, labelTriW,labelTriH);
-const QRect AndZMuxLabel            = QRect(416 + controlOffsetX, 644, 41,21);
+const QRect AndZLabel               = QRect(ctrlLabelX,  OneByteShapes::ALUBottomBound+aluOffsetY+ANDZYOffsetFromALU, 45,     20);
+const QRect AndZTristateLabel       = QRect(ctrlInputX, OneByteShapes::ALUBottomBound+aluOffsetY+ANDZYOffsetFromALU, labelTriW,labelTriH);
+const QRect AndZMuxLabel            = QRect(416 + controlOffsetX, OneByteShapes::ALUBottomBound+aluOffsetY+ANDZYOffsetFromALU+27, 41,21);
 
 // Status bit Z, ZCk and its control
-const QRect ZCkCheckBox             = QRect(ctrlInputX, 644, 60, 20);
-const QRect zBitLabel               = QRect(statusBitsX, 644, 19, dataLabelH);
+const QRect ZCkCheckBox             = QRect(ctrlInputX, OneByteShapes::ALUBottomBound+aluOffsetY+ZCkYOffsetFromALU, 60, 20);
+const QRect zBitLabel               = QRect(statusBitsX, OneByteShapes::ALUBottomBound+aluOffsetY+ZCkYOffsetFromALU, 19, dataLabelH);
 
 // Status bit N, NCk and its control
-const QRect NCkCheckBox             = QRect(ctrlInputX, 686, checkW, checkH);
-const QRect nBitLabel               = QRect(statusBitsX, 686, 19, dataLabelH);
+const QRect NCkCheckBox             = QRect(ctrlInputX, OneByteShapes::ALUBottomBound+aluOffsetY+NCkYOffsetFromALU, checkW, checkH);
+const QRect nBitLabel               = QRect(statusBitsX, OneByteShapes::ALUBottomBound+aluOffsetY+NCkYOffsetFromALU, 19, dataLabelH);
 
 // MemWrite and its control
 const QRect MemWriteLabel           = QRect(ctrlLabelX, 711, check2W, check2H);
@@ -368,28 +378,29 @@ const QPolygon AddrArrow                    = OneByteShapes::AddrArrow;
 //const QPolygon DataToMDRMuxBus;
 const QPolygon DataToMDROMuxBus = QPolygon(QVector<QPoint>()
                                            // foot:
-                                           << QPoint(190 - iRegXOffset, 344)
-                                           << QPoint(80,  344)
-                                           << QPoint(80,  334)
-                                           << QPoint(180 - iRegXOffset, 334)
+                                           << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2+5, MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+18) //Point between vertical right leg and lower horizontal leg
+                                           << QPoint(80,  MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+18) //Lower left corner on bus
+                                           << QPoint(80,  MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+8) //Upper left corner on bus
+                                           << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2-5, MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+8) //Point between vertical left leg and upper horizontal leg
                                            // arrowhead:
-                                           << QPoint(180 - iRegXOffset, 326)
-                                           << QPoint(175 - iRegXOffset, 326)
-                                           << QPoint(185 - iRegXOffset, 316)
-                                           << QPoint(195 - iRegXOffset, 326)
-                                           << QPoint(190 - iRegXOffset, 326));
+                                           << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2-5, MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) //arrow inner left edge
+                                           << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2-10, MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) //arrow outer left edge
+                                           << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2, MDROMuxerDataLabel.bottom()+arrowHOffset) //arrow midpoint
+                                           << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2+10, MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) //arrow right outer edge
+                                           << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2+5, MDROMuxerDataLabel.bottom()+(arrowHDepth-5))); //arrow inner left edge
 
 const QPolygon DataToMDREMuxBus = QPolygon(QVector<QPoint>()
                                            // foot:
-                                           << QPoint(190 - iRegXOffset, 344+100)
-                                           << QPoint(80,  344+100) << QPoint(80,  334+100)
-                                           << QPoint(180 - iRegXOffset, 334+100)
+                                           << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2+5, MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+18) //Point between vertical right leg and lower horizontal leg
+                                           << QPoint(80,  MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+18) //Lower left corner on bus
+                                           << QPoint(80,  MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+8) //Upper left corner on bus
+                                           << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2-5, MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+8) //Point between vertical left leg and upper horizontal leg
                                            // arrowhead:
-                                           << QPoint(180 - iRegXOffset, 326+100)
-                                           << QPoint(175 - iRegXOffset, 326+100)
-                                           << QPoint(185 - iRegXOffset, 316+100)
-                                           << QPoint(195 - iRegXOffset, 326+100)
-                                           << QPoint(190 - iRegXOffset, 326+100));
+                                           << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2-5, MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //arrow inner left edge
+                                           << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2-10, MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //arrow outer left edge
+                                           << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2, MDREMuxerDataLabel.bottom()+arrowHOffset) //arrow midpoint
+                                           << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2+10, MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //arrow right outer edge
+                                           << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2+5, MDREMuxerDataLabel.bottom()+(arrowHDepth-5))); //arrow inner left edge
 //const QPolygon MDRToDataBus;
 const QPolygon MDROToDataBus = QPolygon(QVector<QPoint>()  << QPoint(MDROLabel.x(), 258)
                                         << QPoint(DataBus.x()+DataBus.width()+13, 258)
@@ -486,7 +497,7 @@ const QLine MemReadSelect  = QLine(DataBus.right()   + arrowHOffset,
 const QLine MemWriteSelect = QLine(DataBus.right()   + arrowHOffset,
                                   MemWriteLabel.y() + selectYOffset,
                                   ctrlInputX - 7,
-                                  MemWriteLabel.y() + selectYOffset);
+                                  MemWriteLabel.y() + selectYOffset); //Doesn't draw vertical lines
 
 }
 


### PR DESCRIPTION
Added EOMux output bus to AMux.
Properly draw MARck Arrows.
Properly aligned SBitLine in the two byte model.
Added basic painting functionality to EOMuxOutputBus.

Shifted MARA, MARB, MDRO, MDRE, MARMux, MDROMux, and MDREMux further to the left.
Adjusted some definitions of above combinational cricuits to be relative to other circuits, and not absolute.

These changes are still incremental, and hopefully we can have a chance to re-align the control lines soon.