### PR TITLE
EOMux buses & ABC bus rendering

### DIFF
--- a/cpugraphicsitems.cpp
+++ b/cpugraphicsitems.cpp
@@ -1273,15 +1273,14 @@ void CpuGraphicsItems::paint(QPainter *painter,
         repaintMDROCk(painter);
         repaintMDRECk(painter);
         repaintEOMuxSelect(painter);
-        repaintEOMuxOutpusBus(painter);
         repaintMDROSelect(painter);
         repaintMDRESelect(painter);
         repaintMARMUXToMARBuses(painter);
         repaintMDRMuxOutputBuses(painter);
         //Every select line above ALU firt first
-        //repaintMDREvenBus()
-        //repaintMDROddBus()
-        //repaintEOMuxBus()
+        repaintMDREToEOMuxBus(painter);
+        repaintMDROToEOMuxBus(painter);
+        repaintEOMuxOutpusBus(painter);
         //repaintB()
         //repaintA()
         //repaintC()
@@ -2902,4 +2901,18 @@ void CpuGraphicsItems::repaintMDRMuxOutputBuses(QPainter *painter)
 
 
 }
+void CpuGraphicsItems::repaintMDREToEOMuxBus(QPainter *painter){
+    QColor color = Qt::white;
+    painter->setPen(Qt::black);
+    painter->setBrush(color);
+    painter->drawPolygon(TwoByteShapes::MDREToEOMuxBus);
+}
+
+void CpuGraphicsItems::repaintMDROToEOMuxBus(QPainter *painter){
+    QColor color=Qt::white;
+    painter->setPen(Qt::black);
+    painter->setBrush(color);
+    painter->drawPolygon(TwoByteShapes::MDROToEOMuxBus);
+}
+
 

--- a/cpugraphicsitems.cpp
+++ b/cpugraphicsitems.cpp
@@ -1269,7 +1269,6 @@ void CpuGraphicsItems::paint(QPainter *painter,
         painter->drawText(TwoByteShapes::MARALabel.x() - 37, TwoByteShapes::MARALabel.y() + 13, "MARA");
         painter->drawText(TwoByteShapes::MARBLabel.x() - 37, TwoByteShapes::MARBLabel.y() + 13, "MARB");
 
-        repaintMARMuxSelect(painter);
         repaintMDROCk(painter);
         repaintMDRECk(painter);
         repaintEOMuxSelect(painter);
@@ -1278,6 +1277,7 @@ void CpuGraphicsItems::paint(QPainter *painter,
         repaintMARMUXToMARBuses(painter);
         repaintMDRMuxOutputBuses(painter);
         //Every select line above ALU firt first
+        repaintMARMuxSelect(painter);
         repaintMDREToEOMuxBus(painter);
         repaintMDROToEOMuxBus(painter);
         repaintEOMuxOutpusBus(painter);
@@ -1440,7 +1440,6 @@ void CpuGraphicsItems::repaintMARCk(QPainter *painter)
     }
 }
 
-
 void CpuGraphicsItems::repaintAMuxSelect(QPainter *painter)
 {
     QColor color;
@@ -1515,19 +1514,6 @@ void CpuGraphicsItems::repaintMARMuxSelect(QPainter *painter)
     painter->drawImage(TwoByteShapes::MARMuxSelect._arrowheads.first(),
                        color == Qt::gray ? arrowDownGray : arrowDown);
 
-}
-
-void CpuGraphicsItems::repaintMDROSelect(QPainter *painter)
-{
-    //Determine if control line is high, so that the color may be set accordingly
-    bool MDROIsHigh=MDROMuxTristateLabel->text()=="1";
-    QColor MDROColor=MDROIsHigh?Qt::black:Qt::gray;
-
-    //Paint MDROSelect's lines and arrow in the appropriate color
-    painter->setPen(MDROColor);
-    painter->drawLines(TwoByteShapes::MDROMuxSelect._lines);
-    painter->drawImage(TwoByteShapes::MDROMuxSelect._arrowheads.first(),
-                       MDROColor == Qt::gray ? arrowLeftGray : arrowLeft);
 }
 
 void CpuGraphicsItems::repaintEOMuxSelect(QPainter *painter)
@@ -2137,7 +2123,6 @@ void CpuGraphicsItems::repaintMARCkOneByteModel(QPainter *painter)
                        color == Qt::gray ? arrowDownGray : arrowDown);
 }
 
-
 void CpuGraphicsItems::repaintMDRCk(QPainter *painter)
 {
     QColor color;
@@ -2490,13 +2475,12 @@ void CpuGraphicsItems::repaintMARCkTwoByteModel(QPainter *painter)
     painter->drawLines(TwoByteShapes::MARCk._lines);
 
 
-    painter->drawEllipse(QPoint(TwoByteShapes::MARCk._lines.last().x1(),177), 2, 2);
+    painter->drawEllipse(QPoint(TwoByteShapes::MARCk._lines.last().x1(),TwoByteShapes::MARMuxerDataLabel.y()+TwoByteShapes::MARMuxerDataLabel.height()/2), 2, 2);
     painter->drawImage(TwoByteShapes::MARCk._arrowheads[0],
             color == Qt::gray ? arrowUpGray : arrowUp);
     painter->drawImage(TwoByteShapes::MARCk._arrowheads[1],
             color == Qt::gray ? arrowDownGray : arrowDown);
 }
-
 
 void CpuGraphicsItems::repaintMDROCk(QPainter *painter)
 {
@@ -2513,36 +2497,31 @@ void CpuGraphicsItems::repaintMDROCk(QPainter *painter)
 
 void CpuGraphicsItems::repaintMDRECk(QPainter *painter)
 {
-//    QColor color;
+    QColor color;
+    color = MDRECk->isChecked() ? Qt::black : Qt::gray;
+    painter->setPen(QPen(QBrush(color), 1));
+    painter->setBrush(color);
 
-//    switch (Pep::cpuFeatures) {
-//    case Enu::OneByteDataBus:
-
-//        color = MDRCk->isChecked() ? Qt::black : Qt::gray;
-//        painter->setPen(QPen(QBrush(color), 1));
-//        painter->setBrush(color);
-
-//        // MDRCk
-//        painter->drawLines(OneByteShapes::MDRCk._lines);
-
-//        painter->drawImage(QPoint(207,241),
-//                           color == Qt::gray ? arrowDownGray : arrowDown);
-//        break;
-//    case Enu::TwoByteDataBus:
-
-//        break;
-//    default:
-//        break;
-//    }
+    // MDREven Clock
+    painter->drawLines(TwoByteShapes::MDREck._lines);
+    painter->drawImage(TwoByteShapes::MDREck._arrowheads.first(),
+                       color == Qt::gray ? arrowDownGray : arrowDown);
 
 }
 
 void CpuGraphicsItems::repaintEOMuxOutpusBus(QPainter *painter)
 {
     QColor color = Qt::white;
+    if(EOMuxTristateLabel->text()=="1"){
+        color=combCircuitYellow;
+    }
+    else if(EOMuxTristateLabel->text()=="0"){
+        color=combCircuitYellow;
+    }
     painter->setPen(Qt::black);
     painter->setBrush(color);
     painter->drawPolygon(TwoByteShapes::EOMuxOutputBus);
+    EOMuxerDataLabel->setPalette(color);
 }
 
 void CpuGraphicsItems::repaintALUSelectTwoByteModel(QPainter *painter)
@@ -2719,9 +2698,8 @@ void CpuGraphicsItems::repaintMemWriteTwoByteModel(QPainter *painter)
     painter->drawEllipse(QPoint(TwoByteShapes::DataBus.right()+20,
                                 TwoByteShapes::MemWriteSelect.y1()),
                          2, 2);
-    painter->drawLine(TwoByteShapes::DataBus.right()+20,719, TwoByteShapes::DataBus.right()+20,345); //611+8
+    painter->drawLine(TwoByteShapes::DataBus.right()+20,TwoByteShapes::MemWriteSelect.y1(), TwoByteShapes::DataBus.right()+20,TwoByteShapes::MDROLabel.bottom()); //611+8
     // memWrite line from the label to the bus:
-    painter->drawLine(TwoByteShapes::DataBus.right()+20,333, TwoByteShapes::DataBus.right()+20,280); //268+12
     painter->drawImage(QPoint(TwoByteShapes::DataBus.right()+17, //96-3
                               //The bottom of the bus is 5 pixels below the label's midpoint, and add 3 pixels for visual comfort.
                               TwoByteShapes::MDROLabel.y()+TwoByteShapes::MDROLabel.height()/2+5+3),
@@ -2831,7 +2809,7 @@ void CpuGraphicsItems::repaintMARMUXToMARBuses(QPainter *painter)
 void CpuGraphicsItems::repaintMDRESelect(QPainter *painter)
 {
     //Determine if control line is high, so that the color may be set accordingly
-    bool MDREIsHigh=MDREMuxTristateLabel->text()=="1";
+    bool MDREIsHigh=MDREMuxTristateLabel->text()=="1"||MDREMuxTristateLabel->text()=="0";
     QColor MDREColor=MDREIsHigh?Qt::black:Qt::gray;
 
     //Paint MDRESelect's lines and arrow in the appropriate color
@@ -2847,44 +2825,52 @@ void CpuGraphicsItems::repaintMDRESelect(QPainter *painter)
     }
 }
 
+void CpuGraphicsItems::repaintMDROSelect(QPainter *painter)
+{
+    //Determine if control line is high, so that the color may be set accordingly
+    bool MDROIsHigh=MDROMuxTristateLabel->text()=="1"||MDROMuxTristateLabel->text()=="0";
+    QColor MDROColor=MDROIsHigh?Qt::black:Qt::gray;
+
+    //Paint MDROSelect's lines and arrow in the appropriate color
+    painter->setPen(MDROColor);
+    painter->drawLines(TwoByteShapes::MDROMuxSelect._lines);
+    painter->drawImage(TwoByteShapes::MDROMuxSelect._arrowheads.first(),
+                       MDROColor == Qt::gray ? arrowLeftGray : arrowLeft);
+    if(MDROIsHigh){
+        MDROMuxerDataLabel->setPalette(QPalette(combCircuitGreen));
+    }
+    else{
+        MDROMuxerDataLabel->setPalette(QPalette(Qt::white));
+    }
+}
+
 void CpuGraphicsItems::repaintMDRMuxOutputBuses(QPainter *painter)
 {
     // MDRMuxOutBus (MDRMux to MDR arrow)
-    QColor colorMDRE = Qt::white,colorMDRO=Qt::white;
+    QColor colorMDRE = Qt::white, colorMDRO = Qt::white;
     // Depending on which input is selected on the MDRMuxes, the color might need to change.
     // For now red seems to be the most logical color to use all the time.
-    QString MDREText =MDREMuxTristateLabel->text(), MDROText=MDROMuxTristateLabel->text();
+    QString MDREText = MDREMuxTristateLabel->text(), MDROText = MDROMuxTristateLabel->text();
     if(MDRECk->isChecked()&&(MDREText=="1"||MDREText=="0")){
-        colorMDRE=combCircuitGreen.lighter(120);
+         //If the muxer is enabled, and data can be clocked in to the register, pick an appropriate color
+        colorMDRE = combCircuitGreen.lighter(120);
     }
     if(MDROCk->isChecked()&&(MDROText=="1"||MDROText=="0")){
-        colorMDRO=combCircuitGreen.lighter(120);
+         //If the muxer is enabled, and data can be clocked in to the register, pick an appropriate color
+        colorMDRO = combCircuitGreen.lighter(120);
     }
     painter->setPen(Qt::black);
     painter->setBrush(colorMDRE);
     painter->drawPolygon(TwoByteShapes::MDREMuxOutBus);
     painter->setBrush(colorMDRO);
     painter->drawPolygon(TwoByteShapes::MDROMuxOutBus);
-
-    // Selection lines are now handled in a seperate function, but the code originall used to do it is preserved here.
-    //QColor color = Qt::gray;
-    //if (MDREMuxTristateLabel->text() != "") {
-    //    color = Qt::black;
-    //}
-    //painter->setPen(color);
-    //painter->setBrush(color);
-    // MDRMux Select
-    //painter->drawLine(257,303, 265,303); painter->drawLine(265,303, 265,324);
-    //painter->drawLine(265,324, 279,324); painter->drawLine(291,324, 335,324);
-    //painter->drawLine(347,324, 416,324); painter->drawLine(428,324, 543,324);
-
-    /*painter->drawImage(QPoint(249,300),
-                       color == Qt::gray ? arrowLeftGray : arrowLeft);*/
-
-
 }
+
 void CpuGraphicsItems::repaintMDREToEOMuxBus(QPainter *painter){
     QColor color = Qt::white;
+    if(MARMuxTristateLabel->text()=="0"||EOMuxTristateLabel->text()=="1"||EOMuxTristateLabel->text()=="0"){
+        color=Qt::blue;
+    }
     painter->setPen(Qt::black);
     painter->setBrush(color);
     painter->drawPolygon(TwoByteShapes::MDREToEOMuxBus);
@@ -2892,10 +2878,14 @@ void CpuGraphicsItems::repaintMDREToEOMuxBus(QPainter *painter){
 
 void CpuGraphicsItems::repaintMDROToEOMuxBus(QPainter *painter){
     QColor color=Qt::white;
+    if(MARMuxTristateLabel->text()=="0"||EOMuxTristateLabel->text()=="1"||EOMuxTristateLabel->text()=="0"){
+        color=Qt::blue;
+    }
     painter->setPen(Qt::black);
     painter->setBrush(color);
     painter->drawPolygon(TwoByteShapes::MDROToEOMuxBus);
 }
+
 void CpuGraphicsItems::repaintABusTwoByteModel(QPainter *painter)
 {
     bool ok;
@@ -2908,6 +2898,7 @@ void CpuGraphicsItems::repaintABusTwoByteModel(QPainter *painter)
     // ABus
     painter->drawPolygon(TwoByteShapes::ABus);
 }
+
 void CpuGraphicsItems::repaintBBusTwoByteModel(QPainter *painter)
 {
     bool ok;
@@ -2920,6 +2911,7 @@ void CpuGraphicsItems::repaintBBusTwoByteModel(QPainter *painter)
     // BBus
     painter->drawPolygon(TwoByteShapes::BBus);
 }
+
 void CpuGraphicsItems::repaintCBusTwoByteModel(QPainter *painter)
 {
     bool ok;

--- a/cpugraphicsitems.cpp
+++ b/cpugraphicsitems.cpp
@@ -1214,7 +1214,7 @@ void CpuGraphicsItems::paint(QPainter *painter,
     repaintBSelect(painter);
     repaintASelect(painter);
     repaintMARCk(painter);
-
+    repaintAMuxSelect(painter); // Needs to be painted before buses
     painter->setPen(Qt::black);
 
     switch (Pep::cpuFeatures) {
@@ -1290,7 +1290,6 @@ void CpuGraphicsItems::paint(QPainter *painter,
         break;
     }
 
-    repaintAMuxSelect(painter);
 
     repaintCMuxSelect(painter);
 

--- a/cpugraphicsitems.cpp
+++ b/cpugraphicsitems.cpp
@@ -1281,9 +1281,9 @@ void CpuGraphicsItems::paint(QPainter *painter,
         repaintMDREToEOMuxBus(painter);
         repaintMDROToEOMuxBus(painter);
         repaintEOMuxOutpusBus(painter);
-        //repaintB()
-        //repaintA()
-        //repaintC()
+        repaintABusTwoByteModel(painter);
+        repaintBBusTwoByteModel(painter);
+        repaintCBusTwoByteModel(painter);
 
         break;
     default:
@@ -1392,15 +1392,6 @@ void CpuGraphicsItems::repaintBSelect(QPainter *painter)
         break;
     case Enu::TwoByteDataBus:
         painter->drawLines(TwoByteShapes::BSelect._lines);
-
-        color = ok ? combCircuitRed : Qt::white;
-        painter->setPen(QPen(QBrush(Qt::black), 1));
-        painter->setBrush(color);
-
-        // BBus
-        painter->drawPolygon(TwoByteShapes::BBus1);
-        painter->drawPolygon(TwoByteShapes::BBus2);
-        painter->drawRect(TwoByteShapes::BBusRect);
         break;
     default:
         break;
@@ -1429,15 +1420,6 @@ void CpuGraphicsItems::repaintASelect(QPainter *painter)
         break;
     case Enu::TwoByteDataBus:
         painter->drawLines(TwoByteShapes::ASelect._lines);
-
-        color = ok ? combCircuitRed : Qt::white;
-
-        painter->setPen(QPen(QBrush(Qt::black), 1));
-        painter->setBrush(color);
-        // ABus
-        painter->drawPolygon(TwoByteShapes::ABus1);
-        painter->drawPolygon(TwoByteShapes::ABus2);
-
         break;
     default:
         break;
@@ -2914,5 +2896,42 @@ void CpuGraphicsItems::repaintMDROToEOMuxBus(QPainter *painter){
     painter->setBrush(color);
     painter->drawPolygon(TwoByteShapes::MDROToEOMuxBus);
 }
+void CpuGraphicsItems::repaintABusTwoByteModel(QPainter *painter)
+{
+    bool ok;
+    aLineEdit->text().toInt(&ok, 10);
+    QColor color;
+    color = ok ? combCircuitRed : Qt::white;
+    painter->setPen(QPen(QBrush(Qt::black), 1));
+    painter->setBrush(color);
+
+    // ABus
+    painter->drawPolygon(TwoByteShapes::ABus);
+}
+void CpuGraphicsItems::repaintBBusTwoByteModel(QPainter *painter)
+{
+    bool ok;
+    bLineEdit->text().toInt(&ok, 10);
+    QColor color;
+    color = ok ? combCircuitRed : Qt::white;
+    painter->setPen(QPen(QBrush(Qt::black), 1));
+    painter->setBrush(color);
+
+    // BBus
+    painter->drawPolygon(TwoByteShapes::BBus);
+}
+void CpuGraphicsItems::repaintCBusTwoByteModel(QPainter *painter)
+{
+    bool ok;
+    cLineEdit->text().toInt(&ok, 10);
+    QColor color;
+    color = ok ? combCircuitRed : Qt::white;
+    painter->setPen(QPen(QBrush(Qt::black), 1));
+    painter->setBrush(color);
+
+    // CBus
+    painter->drawPolygon(TwoByteShapes::CBus);
+}
+
 
 

--- a/cpugraphicsitems.h
+++ b/cpugraphicsitems.h
@@ -217,6 +217,8 @@ private:
     void repaintMARMUXToMARBuses(QPainter *painter);
 
     void repaintMDRMuxOutputBuses(QPainter *painter);
+    void repaintMDREToEOMuxBus(QPainter *painter);
+    void repaintMDROToEOMuxBus(QPainter *painter);
     void repaintABusTwoByteModel(QPainter *painter);
     void repaintBBusTwoByteModel(QPainter *painter);
     void repaintCBusTwoByteModel(QPainter *painter);

--- a/cpugraphicsitems.h
+++ b/cpugraphicsitems.h
@@ -201,9 +201,7 @@ private:
     void repaintMARMuxSelect(QPainter *painter);
     void repaintMARCkTwoByteModel(QPainter *painter);
 
-    //Currently does nothing (1/21/18)
     void repaintMDROCk(QPainter *painter);
-    //MDROSelect actually repaints MDROCk
     void repaintMDROSelect(QPainter *painter);
     void repaintMDRESelect(QPainter *painter);
     void repaintMDRECk(QPainter *painter);

--- a/cpupane.cpp
+++ b/cpupane.cpp
@@ -189,6 +189,9 @@ void CpuPane::initModel(Enu::CPUType type)
     connect(cpuPaneItems->MDREMuxTristateLabel, SIGNAL(clicked()), scene, SLOT(invalidate()));
     connect(cpuPaneItems->EOMuxTristateLabel, SIGNAL(clicked()), this, SLOT(labelClicked()));
     connect(cpuPaneItems->EOMuxTristateLabel, SIGNAL(clicked()), scene, SLOT(invalidate()));
+    connect(cpuPaneItems->MDRECk, SIGNAL(clicked()), scene, SLOT(invalidate()));
+    connect(cpuPaneItems->MDROCk, SIGNAL(clicked()), scene, SLOT(invalidate()));
+
 }
 
 void CpuPane::startDebugging()

--- a/shapes_one_byte_data_bus.h
+++ b/shapes_one_byte_data_bus.h
@@ -241,12 +241,15 @@ enum ALUPolyNumbers
 {
     ALUUpperLeftLine_LeftPoint = 314,
     ALUUpperLeftLine_RightPoint=366,
+    ALUUpperRightLine_LeftPoint=394,
+    ALUUpperRightLine_RightPoint=447,
+    ALUTopBound=342,
     ALUBottomBound=394,
 };
-const QPolygon ALUPoly = QPolygon(QVector<QPoint>() << QPoint(ALUUpperLeftLine_LeftPoint,342)
-                                  << QPoint(ALUUpperLeftLine_RightPoint,342) << QPoint(370,353)
-                                  << QPoint(390,353) << QPoint(394,342)
-                                  << QPoint(447,342) << QPoint(421,ALUBottomBound)
+const QPolygon ALUPoly = QPolygon(QVector<QPoint>() << QPoint(ALUUpperLeftLine_LeftPoint,ALUTopBound)
+                                  << QPoint(ALUUpperLeftLine_RightPoint,ALUTopBound) << QPoint(370,353)
+                                  << QPoint(390,353) << QPoint(ALUUpperRightLine_LeftPoint,ALUTopBound)
+                                  << QPoint(ALUUpperRightLine_RightPoint,ALUTopBound) << QPoint(421,ALUBottomBound)
                                   << QPoint(340,ALUBottomBound));
 
 // the two shapes that make up the arrow out to the right of the MDR

--- a/shapes_two_byte_data_bus.h
+++ b/shapes_two_byte_data_bus.h
@@ -62,7 +62,7 @@ enum Shapes {
     incrementerOffset = 10,
 
     aluSelOff = 57,
-    aluOffsetY = 156,
+    aluOffsetY = 160,
     selLineOff = 15,
 
 };
@@ -429,7 +429,38 @@ const QPolygon MDREToDataBus = QPolygon(QVector<QPoint>()
                                         << QPoint(DataBus.x()+DataBus.width()+13, MDRELabel.y()+MDRELabel.height()/2+10)    //Arrow Outer Lower Point
                                         << QPoint(DataBus.x()+DataBus.width()+13, MDRELabel.y()+MDRELabel.height()/2+5)     //Arrow Inner Lower Point
                                         << QPoint(MDRELabel.x(), MDRELabel.y()+MDRELabel.height()/2+5));                    //Bottom Right Corner
-
+const QPolygon MDREToEOMuxBus = QPolygon(QVector<QPoint>()
+                                         << QPoint(MDRELabel.right()+1,MDRELabel.y()+MDRELabel.height()/2 - 5) //MDRE Top Point
+                                         << QPoint(MDRELabel.right()+1,MDRELabel.y()+MDRELabel.height()/2 + 5) //MDRE Bottom Point
+                                         << QPoint(EOMuxerDataLabel.x()+5,MDRELabel.y()+MDRELabel.height()/2 + 5) //Pivot between MDRE bottom and EOMux bottom
+                                         << QPoint(EOMuxerDataLabel.x()+5,EOMuxerDataLabel.y()-(arrowHDepth-5)) //EOMux Arrow Inner Left Edge
+                                         << QPoint(EOMuxerDataLabel.x()+0,EOMuxerDataLabel.y()-(arrowHDepth-5)) //EOMux Arrow Outer Left Edge
+                                         << QPoint(EOMuxerDataLabel.x()+10,EOMuxerDataLabel.y()-(arrowHOffset)) //EOMux Arrow Midpoint
+                                         << QPoint(EOMuxerDataLabel.x()+20,EOMuxerDataLabel.y()-(arrowHDepth-5)) //EOMux Arrow Outer Right Edge
+                                         << QPoint(EOMuxerDataLabel.x()+15,EOMuxerDataLabel.y()-(arrowHDepth-5)) //EOMux Arrow Inner Right Edge
+                                         << QPoint(EOMuxerDataLabel.x()+15,MARMuxerDataLabel.bottom()+(arrowHDepth-5)) //MARMux Arrow Inner Right Edge
+                                         << QPoint(EOMuxerDataLabel.x()+20,MARMuxerDataLabel.bottom()+(arrowHDepth-5)) //MARMux Arrow Outer Right Edge
+                                         << QPoint(EOMuxerDataLabel.x()+10,MARMuxerDataLabel.bottom()+(arrowHOffset)) //MARMux Arrow Midpoint
+                                         << QPoint(EOMuxerDataLabel.x()+0,MARMuxerDataLabel.bottom()+(arrowHDepth-5)) //MARMux Arrow Outer Left Edge
+                                         << QPoint(EOMuxerDataLabel.x()+5,MARMuxerDataLabel.bottom()+(arrowHDepth-5)) //MARMux Arrow Inner Left Edge
+                                         << QPoint(EOMuxerDataLabel.x()+5,MDRELabel.y()+MDRELabel.height()/2 -5) //Pivot between MARMux bottom and MDRE top
+                                         );
+const QPolygon MDROToEOMuxBus = QPolygon(QVector<QPoint>()
+                                         << QPoint(MDROLabel.right()+1,MDROLabel.y()+MDROLabel.height()/2 - 5) //MDRE Top Point
+                                         << QPoint(MDROLabel.right()+1,MDROLabel.y()+MDROLabel.height()/2 + 5) //MDRE Bottom Point
+                                         << QPoint(EOMuxerDataLabel.right()-15,MDROLabel.y()+MDROLabel.height()/2 + 5) //Pivot between MDRE bottom and EOMux bottom
+                                         << QPoint(EOMuxerDataLabel.right()-15,EOMuxerDataLabel.y()-(arrowHDepth-5)) //EOMux Arrow Inner Left Edge
+                                         << QPoint(EOMuxerDataLabel.right()-20,EOMuxerDataLabel.y()-(arrowHDepth-5)) //EOMux Arrow Outer Left Edge
+                                         << QPoint(EOMuxerDataLabel.right()-10,EOMuxerDataLabel.y()-(arrowHOffset)) //EOMux Arrow Midpoint
+                                         << QPoint(EOMuxerDataLabel.right()-0,EOMuxerDataLabel.y()-(arrowHDepth-5)) //EOMux Arrow Outer Right Edge
+                                         << QPoint(EOMuxerDataLabel.right()-5,EOMuxerDataLabel.y()-(arrowHDepth-5)) //EOMux Arrow Inner Right Edge
+                                         << QPoint(EOMuxerDataLabel.right()-5,MARMuxerDataLabel.bottom()+(arrowHDepth-5)) //MARMux Arrow Inner Right Edge
+                                         << QPoint(EOMuxerDataLabel.right()+0,MARMuxerDataLabel.bottom()+(arrowHDepth-5)) //MARMux Arrow Outer Right Edge
+                                         << QPoint(EOMuxerDataLabel.right()-10,MARMuxerDataLabel.bottom()+(arrowHOffset)) //MARMux Arrow Midpoint
+                                         << QPoint(EOMuxerDataLabel.right()-20,MARMuxerDataLabel.bottom()+(arrowHDepth-5)) //MARMux Arrow Outer Left Edge
+                                         << QPoint(EOMuxerDataLabel.right()-15,MARMuxerDataLabel.bottom()+(arrowHDepth-5)) //MARMux Arrow Inner Left Edge
+                                         << QPoint(EOMuxerDataLabel.right()-15,MDROLabel.y()+MDROLabel.height()/2 -5) //Pivot between MARMux bottom and MDRE top
+                                         );
 //const QPolygon MDRMuxOutBus;
 const QPolygon MDROMuxOutBus = QPolygon(QVector<QPoint>()
                                         << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2-5, MDROMuxerDataLabel.y()) //Bottom Left Corner

--- a/shapes_two_byte_data_bus.h
+++ b/shapes_two_byte_data_bus.h
@@ -76,6 +76,8 @@ enum CommonPositions {
     combCircY = 142, //Memory Combinational circuits start at this height. Originally 132
     statusBitsX = 526,//476,
     BottomOfAlu=OneByteShapes::ALUBottomBound+aluOffsetY, //Y coordinate of the bottom of the ALU
+    ALUUpperRightLineMidpoint=(OneByteShapes::ALUUpperRightLine_LeftPoint+OneByteShapes::ALUUpperRightLine_RightPoint)/2+controlOffsetX,
+    BBusRightArrowTipX=ctrlInputX,
 
 };
 
@@ -96,7 +98,7 @@ enum CommonOffsets{
     MemReadYOffsetFromALU=237,  //Bottom of ALU to the MemReadLine
     MemWriteYOffsetFromALU=217, //Bottom of ALU to the MemWriteLine
     ALULabelYOffsetFromALU=-25, //Bottom of ALU to top of the ALULineEdit
-    EOMuxOffsetFromMDREMux=10,  //Bottom of MDREMux to top of EOMux
+    EOMuxOffsetFromMDREMux=0,  //Bottom of MDREMux to top of EOMux
 
   };
 
@@ -378,12 +380,76 @@ const QRect m2RegLabel                      = OneByteShapes::m2RegLabel;
 const QRect m3RegLabel                      = OneByteShapes::m3RegLabel;
 const QRect m4RegLabel                      = OneByteShapes::m4RegLabel;
 const QRect m5RegLabel                      = OneByteShapes::m5RegLabel;
-const QPolygon BBus1;
-const QRect BBusRect;
-const QPolygon BBus2;
-const QPolygon ABus1;
-const QPolygon ABus2;
-const QPolygon CBus;
+const QPolygon ABus = QPolygon(QVector<QPoint>()
+                               << QPoint(aMuxerDataLabel.right()-15,RegBank.bottom()+1) //Top left corner of register foot
+                               << QPoint(aMuxerDataLabel.right()-5,RegBank.bottom()+1) //Top right corner of register foot;
+                               << QPoint(aMuxerDataLabel.right()-5,aMuxerDataLabel.y()-(arrowHDepth-5)) //AMux Arrow Right Inner point
+                               << QPoint(aMuxerDataLabel.right()-0,aMuxerDataLabel.y()-(arrowHDepth-5)) //AMux Arrow Right Outer point
+                               << QPoint(aMuxerDataLabel.right()-10,aMuxerDataLabel.y()-arrowHOffset) //AMux Arrow Middle point
+                               << QPoint(aMuxerDataLabel.right()-20,aMuxerDataLabel.y()-(arrowHDepth-5)) //AMux Arrow Left Outer point
+                               << QPoint(aMuxerDataLabel.right()-15,aMuxerDataLabel.y()-(arrowHDepth-5)) //AMux Arrow Left Inner point
+                               << QPoint(aMuxerDataLabel.right()-15,MARMuxerDataLabel.bottom()-5) //Pivot between AMUX arrow left point and MARMux Inner Bottom Edge
+                               << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.bottom()-5) //MARMux Arrow Bottom Inner point
+                               << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.bottom()-0) //MARMux Arrow Bottom Outer point
+                               << QPoint(MARMuxerDataLabel.right()+(arrowHOffset),MARMuxerDataLabel.bottom()-10) //MARMux Arrow Middle point
+                               << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.bottom()-20) //MARMux Arrow Top Outer point
+                               << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.bottom()-15) //MARMux Arrow Top Inner point
+                               << QPoint(aMuxerDataLabel.right()-15,MARMuxerDataLabel.bottom()-15) //Pivot between MARMux arrow top and register top left foot
+                               );
+const QPolygon BBus = QPolygon(QVector<QPoint>()
+                              << QPoint(ALUUpperRightLineMidpoint-5,RegBank.bottom()+1) //Top left corner of register foot
+                              << QPoint(ALUUpperRightLineMidpoint+5,RegBank.bottom()+1) //Top right corner of register foot
+                              << QPoint(ALUUpperRightLineMidpoint+5,MARMuxerDataLabel.y()+5) //Pivot between register foor and right output
+                              << QPoint(BBusRightArrowTipX-(arrowHDepth-5), MARMuxerDataLabel.y()+5) //Right Out Arrow Top Inner point
+                              << QPoint(BBusRightArrowTipX-(arrowHDepth-5),MARMuxerDataLabel.y()+0) //Right Out Arrow Top Outer point
+                              << QPoint(BBusRightArrowTipX-(arrowHOffset),MARMuxerDataLabel.y()+10) //Right Out Arrow Middle point
+                              << QPoint(BBusRightArrowTipX-(arrowHDepth-5),MARMuxerDataLabel.y()+20) //Right Out Arrow Botton Outer point
+                              << QPoint(BBusRightArrowTipX-(arrowHDepth-5),MARMuxerDataLabel.y()+15) //Right Out Arrow Bottom Inner point
+                              << QPoint(ALUUpperRightLineMidpoint+5,MARMuxerDataLabel.y()+15) //Pivot between right out arrow and alu arrow
+                              << QPoint(ALUUpperRightLineMidpoint+5,ALUPoly.boundingRect().y()-(arrowHDepth-5)) //ALU Arrow Right Inner point
+                              << QPoint(ALUUpperRightLineMidpoint+10,ALUPoly.boundingRect().y()-(arrowHDepth-5)) //ALU Arrow Right Outer point
+                              << QPoint(ALUUpperRightLineMidpoint+0,ALUPoly.boundingRect().y()-(arrowHOffset)) //ALU Arrow Middle point
+                              << QPoint(ALUUpperRightLineMidpoint-10,ALUPoly.boundingRect().y()-(arrowHDepth-5)) //ALU Arrow Left Outer point
+                              << QPoint(ALUUpperRightLineMidpoint-5,ALUPoly.boundingRect().y()-(arrowHDepth-5)) //ALU Arrow Left Inner point
+                              << QPoint(ALUUpperRightLineMidpoint-5,MARMuxerDataLabel.y()+15) //Pivot between ALU arrow and MARMux Arrow
+                              << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.y()+15) //MARMux Arrow Bottom Inner point
+                              << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.y()+20) //MARMux Arrow Bottom Outer point
+                              << QPoint(MARMuxerDataLabel.right()+(arrowHOffset),MARMuxerDataLabel.y()+10) //MARMux Arrow Middle point
+                              << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.y()+0) //MARMux Arrow Top Outer point
+                              << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.y()+5) //MARMux Arrow Top Inner point
+                              << QPoint(ALUUpperRightLineMidpoint-5,MARMuxerDataLabel.y()+5) //Pivot between MARMux and register foot
+                               );
+const QPolygon CBus = QPolygon(QVector<QPoint>()
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2+5,cMuxerLabel.y()) //CMux Right foot
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,cMuxerLabel.y()) //CMux Left foot
+                               //Branch off to MDREven
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+20) //Pivot between CMux foot and MDRE lower Leg
+                               <<QPoint(MDREMuxerDataLabel.right()-15,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+20) //Pivot between MDRE lower leg and MDRE left arrow
+                               <<QPoint(MDREMuxerDataLabel.right()-15,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Left Inner Point
+                               <<QPoint(MDREMuxerDataLabel.right()-20,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Left Outer Point
+                               <<QPoint(MDREMuxerDataLabel.right()-10,MDREMuxerDataLabel.bottom()+(arrowHOffset)) //MDREMux Arrow Middle Point
+                               <<QPoint(MDREMuxerDataLabel.right()-0,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Right Outer Point
+                               <<QPoint(MDREMuxerDataLabel.right()-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Right Inner Point
+                               <<QPoint(MDREMuxerDataLabel.right()-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+10) //Pivot between MDRE right arrow and MDRE upper leg
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+10) //Pivot between MDRE upper leg and leg upwards
+                               //Resume path to register bank
+                               //Branch off to MDROdd
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+20) //Pivot between CMux foot and MDRE lower Leg
+                               <<QPoint(MDROMuxerDataLabel.right()-15,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+20) //Pivot between MDRE lower leg and MDRE left arrow
+                               <<QPoint(MDROMuxerDataLabel.right()-15,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Left Inner Point
+                               <<QPoint(MDROMuxerDataLabel.right()-20,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Left Outer Point
+                               <<QPoint(MDROMuxerDataLabel.right()-10,MDROMuxerDataLabel.bottom()+(arrowHOffset)) //MDREMux Arrow Middle Point
+                               <<QPoint(MDROMuxerDataLabel.right()-0,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Right Outer Point
+                               <<QPoint(MDROMuxerDataLabel.right()-5,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Right Inner Point
+                               <<QPoint(MDROMuxerDataLabel.right()-5,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+10) //Pivot between MDRE right arrow and MDRE upper leg
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+10) //Pivot between MDRE upper leg and leg upwards
+                               //Resume path to register bank
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,RegBank.bottom()+(arrowHDepth-5))//Register Arrow Left Inner Point
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-10,RegBank.bottom()+(arrowHDepth-5))//Register Arrow Left Outer Point
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2+0,RegBank.bottom()+(arrowHOffset))//Register Arrow Middle Point
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2+10,RegBank.bottom()+(arrowHDepth-5))//Register Arrow Right Outer Point
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2+5,RegBank.bottom()+(arrowHDepth-5))//Register Arrow Right Inner Point
+                               );
 const QPolygon AddrArrow                    = OneByteShapes::AddrArrow;
 //const QPolygon DataToMDRMuxBus;
 const QPolygon DataToMDROMuxBus = QPolygon(QVector<QPoint>()

--- a/shapes_two_byte_data_bus.h
+++ b/shapes_two_byte_data_bus.h
@@ -72,33 +72,34 @@ enum CommonPositions {
     ctrlLabelX = 579 + controlOffsetX,
     ctrlInputX = 550 + controlOffsetX,
     interfaceRegsX = 175,               // x-center of MARB, MARA, ...
-    combCircX = interfaceRegsX - iRegXOffset-20, //Combinational circuits need to be moved further left to fit.
-    combCircY = 152, //Memory Combinational circuits start at this height. Originally 132
+    combCircX = interfaceRegsX - iRegXOffset-20, // Combinational circuits need to be moved further left to fit.
+    combCircY = 152, // Memory Combinational circuits start at this height. Originally 132
     statusBitsX = 526,//476,
     BottomOfAlu=OneByteShapes::ALUBottomBound+aluOffsetY, //Y coordinate of the bottom of the ALU
     ALUUpperRightLineMidpoint=(OneByteShapes::ALUUpperRightLine_LeftPoint+OneByteShapes::ALUUpperRightLine_RightPoint)/2+controlOffsetX,
-    BBusRightArrowTipX=ctrlInputX,
+    BBusRightArrowTipX=ctrlInputX, // How far the B bus goes in the direction of the control section of the CPU.
 
 };
 
-//Enumeration that controls the distance between certain items in the diagram. Hopefully this makes spacing easier to adjust.
+// Enumeration that controls the distance between certain items in the diagram. Hopefully this makes spacing easier to adjust.
 enum CommonOffsets{
-    AMuxYOffsetFromALUPoly=40,  //The number of pixels between AMux and the ALU Polygon
-    MARMUXOffestFromMARA=25,    //Number of pixels between MARMux and (MARA, MARB) horizontally.
-    MARAOffsetFromMARB=60,      //Number of pixels vertically between MARA and MARB
-    MDREOffsetFromCombY=110,    //Number of pixels vertically between MDRO register and the combCircY origin.
-    MDRORegOffsetFromMDREMux=42,//Number of pixels vertically between MDROMux and MDREMux
-    MDRRegOffsetFromMDRMux=20,  //Number of pixels between the bottom of MDRO,MDRE registers and the top of MDROMux, MDREMux
-    SCKYOffsetFromALU=43,       //Number of pixel between bottom of ALU and top of SCk controls
-    CCkYOffsetFromALU=70,       //Bottom of ALU and top of CCk
-    VCkYOffsetFromALU=97,       //Bottom of ALU and top of VCk
-    ANDZYOffsetFromALU=123,     //Bottom of ALU and top of ANDZ
-    ZCkYOffsetFromALU=150,      //Bottom of ALU and top of ZCk
-    NCkYOffsetFromALU=192,      //Bottom of ALU and top of NCk
-    MemReadYOffsetFromALU=237,  //Bottom of ALU to the MemReadLine
-    MemWriteYOffsetFromALU=217, //Bottom of ALU to the MemWriteLine
-    ALULabelYOffsetFromALU=-25, //Bottom of ALU to top of the ALULineEdit
-    EOMuxOffsetFromMDREMux=0,  //Bottom of MDREMux to top of EOMux
+    AMuxYOffsetFromALUPoly=40,  // The number of pixels between AMux and the ALU Polygon
+    MARMUXOffestFromMARA=25,    // Number of pixels between MARMux and (MARA, MARB) horizontally.
+    MARAOffsetFromMARB=60,      // Number of pixels vertically between MARA and MARB
+    MDREOffsetFromCombY=110,    // Number of pixels vertically between MDRO register and the combCircY origin.
+    MDRORegOffsetFromMDREMux=42,// Number of pixels vertically between MDROMux and MDREMux
+    MDRRegOffsetFromMDRMux=20,  // Number of pixels between the bottom of MDRO,MDRE registers and the top of MDROMux, MDREMux
+    SCKYOffsetFromALU=43,       // Number of pixel between bottom of ALU and top of SCk controls
+    CCkYOffsetFromALU=70,       // Bottom of ALU and top of CCk
+    VCkYOffsetFromALU=97,       // Bottom of ALU and top of VCk
+    ANDZYOffsetFromALU=123,     // Bottom of ALU and top of ANDZ
+    ZCkYOffsetFromALU=150,      // Bottom of ALU and top of ZCk
+    NCkYOffsetFromALU=192,      // Bottom of ALU and top of NCk
+    MemReadYOffsetFromALU=237,  // Bottom of ALU to the MemReadLine
+    MemWriteYOffsetFromALU=217, // Bottom of ALU to the MemWriteLine
+    ALULabelYOffsetFromALU=-25, // Bottom of ALU to top of the ALULineEdit
+    EOMuxOffsetFromMDREMux=0,   // Top of MDREMux to top of EOMux
+    CBusToMDREMuxLength=60,     // Number of pixels between the branch of C bus and MDREMux
 
   };
 
@@ -149,57 +150,61 @@ const QRect MARMuxTristateLabel     = QRect(ctrlInputX, MARMuxerDataLabel.y()-28
 const QRect MARMuxLabel             = QRect(ctrlLabelX, MARMuxTristateLabel.y(), labelW+20, labelH);
 const Arrow MARMuxSelect            = Arrow(QVector<QPoint>() << QPoint(MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2-3, MARMuxerDataLabel.y()-12),
                                             QVector<QLine>()
+                                            // Horizontal line from middle of MARMux to the tristate label
                                             << QLine(MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2, MARMuxTristateLabel.y()+MARMuxTristateLabel.height()/2,
-                                                     MARMuxTristateLabel.x(), MARMuxTristateLabel.y()+MARMuxTristateLabel.height()/2) //Horizontal line from middle of MARMux to the tristate label
+                                                     MARMuxTristateLabel.x(), MARMuxTristateLabel.y()+MARMuxTristateLabel.height()/2)
+                                            // Vertical line connecting the arrowhead to the horizontal line
                                             << QLine(MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2, MARMuxTristateLabel.y()+MARMuxTristateLabel.height()/2,
-                                                     MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2,MARMuxerDataLabel.y()-12) //Vertical line connecting the arrowhead to the horizontal line
-                                            );
+                                                     MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2,MARMuxerDataLabel.y()-12));
 
 // MARCk and its control
 const QRect MARCkCheckbox           = QRect(ctrlInputX, MARMuxerDataLabel.y()+MARMuxerDataLabel.height()/2-check2H/2, check2W, check2H);
 const QRect MARALabel               = QRect(combCircX, combCircY+MARAOffsetFromMARB, dataLabelW, dataLabelH); // MARA register.
 const QRect MARBLabel               = QRect(combCircX, combCircY, dataLabelW, dataLabelH); // MARB register
 const Arrow MARCk                   = Arrow(QVector<QPoint>()
-                                            //The Arrows intersecting MAR,MARB should be roughly 5/7 of the way down the circuits.
+                                            // The Arrows intersecting MAR,MARB should be roughly 5/7 of the way down the circuits.
                                             << QPoint(combCircX+5*dataLabelW/7+7,combCircY+dataLabelH+3)
                                             << QPoint(combCircX+5*dataLabelW/7+7,combCircY+MARAOffsetFromMARB-11),
                                             QVector<QLine> ()
+                                            // Horizontal line segment between MARMux and MARCk
                                             << QLine(MARMuxerDataLabel.right()+3,MARMuxerDataLabel.y()+MARMuxerDataLabel.height()/2,
-                                                     MARCkCheckbox.x(),MARMuxerDataLabel.y()+MARMuxerDataLabel.height()/2) //Horizontal line segment between MARMux and MARCk
+                                                     MARCkCheckbox.x(),MARMuxerDataLabel.y()+MARMuxerDataLabel.height()/2)
+                                            // Horizontal line segment between MARMux and MAR{A,B}
                                             << QLine(combCircX+5*dataLabelW/7+10,MARMuxerDataLabel.y()+MARMuxerDataLabel.height()/2,
-                                                     MARMuxerDataLabel.x(),MARMuxerDataLabel.y()+MARMuxerDataLabel.height()/2) //Horizontal line segment between MARMux and MAR{A,B}
-                                            //The vertical lines intersecting MAR,MARB should be roughly 5/7 of the way down the circuits.
+                                                     MARMuxerDataLabel.x(),MARMuxerDataLabel.y()+MARMuxerDataLabel.height()/2)
+                                            // The vertical line intersecting MAR,MARB should be roughly 5/7 of the way down the circuits.
                                             << QLine(combCircX+5*dataLabelW/7+10,combCircY+dataLabelH+3,
-                                                     combCircX+5*dataLabelW/7+10,combCircY+MARAOffsetFromMARB-3));  //Vertical line at left end of MARCk
+                                                     combCircX+5*dataLabelW/7+10,combCircY+MARAOffsetFromMARB-3));
 // MARMux output busses
 const QPolygon MARMuxToMARABus = QPolygon(QVector<QPoint>()
-                                        << QPoint(MARMuxerDataLabel.x(), MARALabel.y()+MARALabel.height()/2-5)               //Top Right Corner
-                                        << QPoint(MARMuxerDataLabel.x(), MARALabel.y()+MARALabel.height()/2+5)               //Bottom Right Corner
-                                        << QPoint(MARALabel.right()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2+5)     //Arrow Bottom Left Inner edge
-                                        << QPoint(MARALabel.right()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2+10)    //Arrow Bottom Left Outer Edge
-                                        << QPoint(MARALabel.right()+arrowHOffset, MARALabel.y()+MARALabel.height()/2)        //Arrow Middle Point
-                                        << QPoint(MARALabel.right()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2-10)    //Arrow Top Left Outer Edge
-                                        << QPoint(MARALabel.right()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2-5));   //Arrow Top Left Inner Edge
+                                        << QPoint(MARMuxerDataLabel.x(), MARALabel.y()+MARALabel.height()/2-5)               // Foot Top Right point
+                                        << QPoint(MARMuxerDataLabel.x(), MARALabel.y()+MARALabel.height()/2+5)               // Foot Bottom Right point
+                                        << QPoint(MARALabel.right()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2+5)     // Arrow Bottom Inner point
+                                        << QPoint(MARALabel.right()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2+10)    // Arrow Bottom Outer point
+                                        << QPoint(MARALabel.right()+arrowHOffset, MARALabel.y()+MARALabel.height()/2)        // Arrow Middle point
+                                        << QPoint(MARALabel.right()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2-10)    // Arrow Top Outer point
+                                        << QPoint(MARALabel.right()+arrowHDepth-5, MARALabel.y()+MARALabel.height()/2-5));   // Arrow Top Inner point
 
 const QPolygon MARMuxToMARBBus = QPolygon(QVector<QPoint>()
-                                        << QPoint(MARMuxerDataLabel.x(), MARBLabel.y()+MARALabel.height()/2-5)               //Top Right Corner
-                                        << QPoint(MARMuxerDataLabel.x(), MARBLabel.y()+MARALabel.height()/2+5)               //Bottom Right Corner
-                                        << QPoint(MARBLabel.right()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2+5)     //Arrow Bottom Left Inner edge
-                                        << QPoint(MARBLabel.right()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2+10)    //Arrow Bottom Left Outer Edge
-                                        << QPoint(MARBLabel.right()+arrowHOffset, MARBLabel.y()+MARALabel.height()/2)        //Arrow Middle Point
-                                        << QPoint(MARBLabel.right()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2-10)    //Arrow Top Left Outer Edge
-                                        << QPoint(MARBLabel.right()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2-5));   //Arrow Top Left Inner Edge
+                                        << QPoint(MARMuxerDataLabel.x(), MARBLabel.y()+MARALabel.height()/2-5)               // Foot Top Right point
+                                        << QPoint(MARMuxerDataLabel.x(), MARBLabel.y()+MARALabel.height()/2+5)               // Bottom Right point
+                                        << QPoint(MARBLabel.right()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2+5)     // Arrow Bottom Inner point
+                                        << QPoint(MARBLabel.right()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2+10)    // Arrow Bottom Outer point
+                                        << QPoint(MARBLabel.right()+arrowHOffset, MARBLabel.y()+MARALabel.height()/2)        // Arrow Middle point
+                                        << QPoint(MARBLabel.right()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2-10)    // Arrow Top Outer point
+                                        << QPoint(MARBLabel.right()+arrowHDepth-5, MARBLabel.y()+MARALabel.height()/2-5));   // Arrow Top Inner point
 
 // MDROdd, MDROCk and its control
 const QRect MDROLabel               = QRect(combCircX, combCircY+MDREOffsetFromCombY, dataLabelW, dataLabelH);
 const QRect MDROCkCheckbox          = QRect(ctrlInputX, MDROLabel.y()-25, checkW+10, checkH);
 const Arrow MDROck              = Arrow(QVector<QPoint>() << QPoint(MDROLabel.x()+MDROLabel.width()/2-3, MDROLabel.y()-12),
                                             QVector<QLine>()
+                                        // Horizontal line from MDRO checkbox to center of MDRO
                                         << QLine(MDROLabel.x()+MDROLabel.width()/2,MDROCkCheckbox.y()+MDROCkCheckbox.height()/2,
-                                                 MDROCkCheckbox.x(),MDROCkCheckbox.y()+MDROCkCheckbox.height()/2) //Horizontal line from MDRO checkbox to center of MDRO
+                                                 MDROCkCheckbox.x(),MDROCkCheckbox.y()+MDROCkCheckbox.height()/2)
+                                        // Vertical line between arrowhead and horizontal line from checkbox
                                         << QLine(MDROLabel.x()+MDROLabel.width()/2,MDROCkCheckbox.y()+MDROCkCheckbox.height()/2,
-                                                 MDROLabel.x()+MDROLabel.width()/2, MDROLabel.y()-12) //Vertical line between arrowhead and horizontal line from checkbox
-                                        );
+                                                 MDROLabel.x()+MDROLabel.width()/2, MDROLabel.y()-12));
 
 // MDROMux and its control
 const QRect MDROMuxerDataLabel      = QRect(combCircX, MDROLabel.bottom()+MDRRegOffsetFromMDRMux, dataLabelW, dataLabelH);
@@ -208,8 +213,9 @@ const QRect MDROMuxLabel            = QRect(ctrlLabelX, MDROMuxTristateLabel.y()
 const Arrow MDROMuxSelect           = Arrow(QVector<QPoint>()
                                             <<QPoint(MDROMuxerDataLabel.right()+5,MDROMuxTristateLabel.y()+MDROMuxTristateLabel.height()/2-3),
                                             QVector<QLine>()
+                                            // Horizontal line between MDROMux and its tristate label
                                             <<QLine(MDROMuxTristateLabel.x(),MDROMuxTristateLabel.y()+MDROMuxTristateLabel.height()/2,
-                                                    MDROMuxerDataLabel.right()+5,MDROMuxTristateLabel.y()+MDROMuxTristateLabel.height()/2) //Horizontal line between MDROMux and its tri state label
+                                                    MDROMuxerDataLabel.right()+5,MDROMuxTristateLabel.y()+MDROMuxTristateLabel.height()/2)
                                             );
 
 // MDREven, MDRECk and its control
@@ -218,11 +224,12 @@ const QRect MDRECkCheckbox          = QRect(ctrlInputX, MDRELabel.y()-30, checkW
 const Arrow MDREck                  = Arrow(QVector<QPoint>()
                                             <<QPoint(MDRELabel.x()+MDRELabel.width()/2-3, MDRELabel.y()-12),
                                             QVector<QLine>()
+                                            // Horizontal line from MDRECk to midpoint of MDREven
                                             << QLine(MDRECkCheckbox.x(),MDROMuxerDataLabel.bottom()+20,
-                                                     MDRELabel.x()+MDRELabel.width()/2,MDROMuxerDataLabel.bottom()+20) //Horizontal line from MDRECk to midpoint of MDREven
+                                                     MDRELabel.x()+MDRELabel.width()/2,MDROMuxerDataLabel.bottom()+20)
+                                            // Vertical line connecting arrowhead and horizontal line segment
                                             << QLine(MDRELabel.x()+MDRELabel.width()/2,MDROMuxerDataLabel.bottom()+20,
-                                                     MDRELabel.x()+MDRELabel.width()/2,MDRELabel.y()-12) //Vertical line connecting arrowhead and horizontal line segment
-                                            );
+                                                     MDRELabel.x()+MDRELabel.width()/2,MDRELabel.y()-12));
 
 // MDREMux and its control
 const QRect MDREMuxerDataLabel      = QRect(combCircX,MDRELabel.bottom()+MDRRegOffsetFromMDRMux, dataLabelW, dataLabelH);
@@ -231,15 +238,17 @@ const QRect MDREMuxLabel            = QRect(ctrlLabelX, MDREMuxTristateLabel.y()
 const Arrow MDREMuxSelect           = Arrow(QVector<QPoint>()
                                             << QPoint(MDREMuxerDataLabel.right()+5,MDREMuxerDataLabel.y()+MDREMuxerDataLabel.height()/2-3),
                                             QVector<QLine>()
+                                            // Horizontal leg extending from MDROCk
                                             << QLine(MDREMuxTristateLabel.x(),MDREMuxTristateLabel.y()+MDREMuxTristateLabel.height()/2,
-                                                     MDREMuxerDataLabel.right()+25 ,MDREMuxTristateLabel.y()+MDREMuxTristateLabel.height()/2) //Horizontal leg extending from MDROCk
+                                                     MDREMuxerDataLabel.right()+25 ,MDREMuxTristateLabel.y()+MDREMuxTristateLabel.height()/2)
+                                            // Vertical line segment
                                             << QLine(MDREMuxerDataLabel.right()+25,MDREMuxTristateLabel.y()+MDREMuxTristateLabel.height()/2,
-                                                     MDREMuxerDataLabel.right()+25,MDREMuxerDataLabel.y()+MDREMuxerDataLabel.height()/2) //Vertical line segment
+                                                     MDREMuxerDataLabel.right()+25,MDREMuxerDataLabel.y()+MDREMuxerDataLabel.height()/2)
+                                             // Horizonal line segment connecting arrowhead and vertical line
                                             << QLine(MDREMuxerDataLabel.right()+25,MDREMuxerDataLabel.y()+MDREMuxerDataLabel.height()/2,
-                                                     MDREMuxerDataLabel.right()+5,MDREMuxerDataLabel.y()+MDREMuxerDataLabel.height()/2) //Horizonal line segment connecting arrowhead and vertical line
-                                            );
+                                                     MDREMuxerDataLabel.right()+5,MDREMuxerDataLabel.y()+MDREMuxerDataLabel.height()/2));
 // EOMux and its control
-const QRect EOMuxerDataLabel        = QRect(MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2-dataLabelW/2, //Center EOMux horizontally on MARMux
+const QRect EOMuxerDataLabel        = QRect(MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2-dataLabelW/2, // Center EOMux horizontally on MARMux
                                             MDREMuxerDataLabel.y()+EOMuxOffsetFromMDREMux, dataLabelW, dataLabelH);
 const QRect EOMuxTristateLabel      = QRect(ctrlInputX, EOMuxerDataLabel.y(), labelTriW, labelTriH);
 const QRect EOMuxLabel              = QRect(ctrlLabelX, EOMuxTristateLabel.y(), labelW, labelH);
@@ -247,8 +256,7 @@ const Arrow EOMuxSelect             = Arrow(QVector<QPoint>() << QPoint(EOMuxerD
                                                                         EOMuxTristateLabel.y()+6),
                                             QVector<QLine>()
                                             <<QLine(EOMuxerDataLabel.right()+5,EOMuxerDataLabel.y()+EOMuxerDataLabel.height()/2,
-                                                    EOMuxTristateLabel.x(),EOMuxerDataLabel.y()+EOMuxerDataLabel.height()/2)
-                                            );
+                                                    EOMuxTristateLabel.x(),EOMuxerDataLabel.y()+EOMuxerDataLabel.height()/2));
 
 
 // ALU and its control
@@ -258,7 +266,7 @@ const QRect ALUFunctionLabel        = OneByteShapes::ALUFunctionLabel.translated
                                                                                  aluOffsetY);
 // CMux and its control
 const QRect cMuxerLabel             = OneByteShapes::cMuxerLabel.translated(controlOffsetX, aluOffsetY);
-const QRect cMuxTristateLabel       = QRect(ctrlInputX, ALULineEdit.y()-labelTriH, labelTriW, labelTriH);
+const QRect cMuxTristateLabel       = QRect(ctrlInputX, ALULineEdit.y()-labelTriH-4, labelTriW, labelTriH);
 const QRect cMuxLabel               = QRect(ctrlLabelX, cMuxTristateLabel.y(), labelW, labelH);
 const Arrow CMuxSelect              = OneByteShapes::CMuxSelect.translated(controlOffsetX, aluOffsetY);
 
@@ -307,70 +315,69 @@ const QRect MDRBusOutRect             = OneByteShapes::MDRBusOutRect;
 const QPolygon MDRBusOutArrow         = OneByteShapes::MDRBusOutArrow;
 const QPolygon MARBus = QPolygon(QVector<QPoint>()
                                  //Top Foot
-                                 << QPoint(MARBLabel.x()+MARBLabel.width()/2-5,MARBLabel.bottom()+1) //Top Left Corner
-                                 << QPoint(MARBLabel.x()+MARBLabel.width()/2-5,(MARBLabel.bottom()+MARALabel.y())/2-10) //Point Between top right corner and inner top Point.
+                                 << QPoint(MARBLabel.x()+MARBLabel.width()/2-5,MARBLabel.bottom()+1) // Foot Top Left point
+                                 << QPoint(MARBLabel.x()+MARBLabel.width()/2-5,(MARBLabel.bottom()+MARALabel.y())/2-10) //P ivot between foot right corner and arrow inner point.
                                  // arrow:
-                                 << QPoint(AddrBus.right()+arrowHDepth,(MARBLabel.bottom()+MARALabel.y())/2-10) //Arrow Inner Top Point
-                                 << QPoint(AddrBus.right()+arrowHDepth,(MARBLabel.bottom()+MARALabel.y())/2-15) //Arrow Outer Top Point
-                                 << QPoint(AddrBus.right()+arrowHOffset,(MARBLabel.bottom()+MARALabel.y())/2+1) //Arrow Middle Point
-                                 << QPoint(AddrBus.right()+arrowHDepth,(MARBLabel.bottom()+MARALabel.y())/2+16) //Arrow Outer bottom Point
-                                 << QPoint(AddrBus.right()+arrowHDepth,(MARBLabel.bottom()+MARALabel.y())/2+10) //Arrow Inner Bottom Point
-                                 //Bottom Foot
-                                 << QPoint(MARALabel.x()+MARBLabel.width()/2-5,(MARBLabel.bottom()+MARALabel.y())/2+10) //Point between bottom right corner and bottom inner point
-                                 << QPoint(MARALabel.x()+MARBLabel.width()/2-5,MARALabel.y()) //Bottom left Corner
-                                 << QPoint(MARALabel.x()+MARBLabel.width()/2+5,MARALabel.y()) //Bottom Right Corner
-                                 //Black Line
-                                 << QPoint(MARBLabel.x()+MARBLabel.width()/2+5,(MARBLabel.bottom()+MARALabel.y())/2) //Black line right point
-                                 << QPoint(AddrBus.right()+arrowHDepth,(MARBLabel.bottom()+MARALabel.y())/2) //Black line left point
-                                 << QPoint(MARBLabel.x()+MARBLabel.width()/2+5,(MARBLabel.bottom()+MARALabel.y())/2) //Black line right point
-                                 //Top Foot
-                                 << QPoint(MARBLabel.x()+MARBLabel.width()/2+5,MARBLabel.bottom()+1)); //Top Right Corner
-                                 // black line in the middle:
+                                 << QPoint(AddrBus.right()+arrowHDepth,(MARBLabel.bottom()+MARALabel.y())/2-10) // Arrow Top Inner Point
+                                 << QPoint(AddrBus.right()+arrowHDepth,(MARBLabel.bottom()+MARALabel.y())/2-15) // Arrow Top Outer Point
+                                 << QPoint(AddrBus.right()+arrowHOffset,(MARBLabel.bottom()+MARALabel.y())/2+1) // Arrow Middle Point
+                                 << QPoint(AddrBus.right()+arrowHDepth,(MARBLabel.bottom()+MARALabel.y())/2+16) // Arrow Bottom Outer Point
+                                 << QPoint(AddrBus.right()+arrowHDepth,(MARBLabel.bottom()+MARALabel.y())/2+10) // Arrow Bottom Inner Point
+                                 // Bottom Foot
+                                 << QPoint(MARALabel.x()+MARBLabel.width()/2-5,(MARBLabel.bottom()+MARALabel.y())/2+10) // Pivot between bottom right corner and bottom inner point
+                                 << QPoint(MARALabel.x()+MARBLabel.width()/2-5,MARALabel.y()) // Foot Bottom Left point
+                                 << QPoint(MARALabel.x()+MARBLabel.width()/2+5,MARALabel.y()) // Foot Bottom Right point
+                                 // Black Line
+                                 << QPoint(MARBLabel.x()+MARBLabel.width()/2+5,(MARBLabel.bottom()+MARALabel.y())/2) // Black line right point
+                                 << QPoint(AddrBus.right()+arrowHDepth,(MARBLabel.bottom()+MARALabel.y())/2) // Black line left point
+                                 << QPoint(MARBLabel.x()+MARBLabel.width()/2+5,(MARBLabel.bottom()+MARALabel.y())/2) // Black line right point
+                                 // Top Foot
+                                 << QPoint(MARBLabel.x()+MARBLabel.width()/2+5,MARBLabel.bottom()+1)); // Foot Top Right point
 
 const QPolygon NZVCDataPath = OneByteShapes::NZVCDataPath.translated(controlOffsetX, aluOffsetY);
 
 // AMux, its controls, selection lines, and output.
 const QRect aMuxerDataLabel         =  QRect(((controlOffsetX+OneByteShapes::ALUUpperLeftLine_LeftPoint)+(controlOffsetX+OneByteShapes::ALUUpperLeftLine_RightPoint))/2-dataLabelW/2,
-                                            //Center AMUX's x on the midpoint of the ALUPolygon, which has been shifted by controlOffsetX pixels.
-                                            ALUPoly.boundingRect().y()-AMuxYOffsetFromALUPoly, dataLabelW, dataLabelH);//Place AMuxYOffsetFromALUPoly pixels distance between AMux and the ALU
+                                            // Center AMUX's x on the midpoint of the ALUPolygon, which has been shifted by controlOffsetX pixels.
+                                            ALUPoly.boundingRect().y()-AMuxYOffsetFromALUPoly, dataLabelW, dataLabelH);// Place AMuxYOffsetFromALUPoly pixels distance between AMux and the ALU
 
 const QRect aMuxTristateLabel       = QRect(ctrlInputX, aMuxerDataLabel.y(), labelTriW, 21);
 const QRect aMuxLabel               = QRect(ctrlLabelX, aMuxTristateLabel.y(), labelW, labelH);
 const Arrow AMuxSelect              = Arrow(QVector<QPoint>()
-                                            //Place the arrowhead slightly off-centered from AMux, otherwise it is visually odd.
+                                            // Place the arrowhead slightly off-centered from AMux, otherwise it is visually odd.
                                             << QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()+3,aMuxerDataLabel.y()+aMuxerDataLabel.height()/2-2),
-                                            //Draw a line from the aMuxTristateLabel to AMux, and center the line vertically between the two.
-                                            //Add one to the calculated y coordinates, otherwise the line and arrow don't appear to be centered.
+                                            // Draw a line from the aMuxTristateLabel to AMux, and center the line vertically between the two.
+                                            // Add one to the calculated y coordinates, otherwise the line and arrow don't appear to be centered.
                                             QVector<QLine>()<<QLine(aMuxTristateLabel.x(),aMuxerDataLabel.y()+aMuxerDataLabel.height()/2+1,
-                                                                    //Add 5 to the x coordinate, otherwise the line extends past the arrow.
+                                                                    // Add 5 to the x coordinate, otherwise the line extends past the arrow.
                                                                     aMuxerDataLabel.x()+aMuxerDataLabel.width()+5,aMuxerDataLabel.y()+aMuxerDataLabel.height()/2+1));
 
 //EOMux bus definition is split from EOMux, because it depends on AMUX, which depends on the ALU
 const QPolygon EOMuxOutputBus          = QPolygon(QVector<QPoint>()
-                                            //Foot
-                                            <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2-5,EOMuxerDataLabel.bottom()+1) //Top Left point
-                                            <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2+5,EOMuxerDataLabel.bottom()+1) //Top Right point
-                                            <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2+5,EOMuxerDataLabel.bottom()+10) //Point between upper right vertical leg, and upper horizontal leg
-                                            <<QPoint(aMuxerDataLabel.x()+15,EOMuxerDataLabel.bottom()+10) //Point between upper horizontal leg, and the right vertical leg
-                                            //Arrow
-                                            <<QPoint(aMuxerDataLabel.x()+15,aMuxerDataLabel.y()-(arrowHDepth-5)) //Arrow inner right point
-                                            <<QPoint(aMuxerDataLabel.x()+20,aMuxerDataLabel.y()-(arrowHDepth-5)) //Arrow outer right point
-                                            <<QPoint(aMuxerDataLabel.x()+10,aMuxerDataLabel.y()-arrowHOffset) //Arrow middle  point
-                                            <<QPoint(aMuxerDataLabel.x(),aMuxerDataLabel.y()-(arrowHDepth-5)) //Arrow outer left point
-                                            <<QPoint(aMuxerDataLabel.x()+5 ,aMuxerDataLabel.y()-(arrowHDepth-5)) //Arrow inner left point
-                                            //Remainder of Foot
-                                            <<QPoint(aMuxerDataLabel.x()+5,EOMuxerDataLabel.bottom()+20) //Point between arrow left side and lower horizontal leg
-                                            <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2-5,EOMuxerDataLabel.bottom()+20) //Point between lower horizontal leg and start
+                                            // Foot
+                                            <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2-5,EOMuxerDataLabel.bottom()+1) // Foot Top Left point
+                                            <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2+5,EOMuxerDataLabel.bottom()+1) // Foot Top Right point
+                                            <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2+5,EOMuxerDataLabel.bottom()+10) // Pivot between upper right vertical leg and upper horizontal leg
+                                            <<QPoint(aMuxerDataLabel.x()+15,EOMuxerDataLabel.bottom()+10) // Pivot between upper horizontal leg, and the right vertical leg
+                                            // Arrow
+                                            <<QPoint(aMuxerDataLabel.x()+15,aMuxerDataLabel.y()-(arrowHDepth-5))    // Arrow Right Inner point
+                                            <<QPoint(aMuxerDataLabel.x()+20,aMuxerDataLabel.y()-(arrowHDepth-5))    // Arrow Right Outer point
+                                            <<QPoint(aMuxerDataLabel.x()+10,aMuxerDataLabel.y()-arrowHOffset)       // Arrow Middle  point
+                                            <<QPoint(aMuxerDataLabel.x(),aMuxerDataLabel.y()-(arrowHDepth-5))       // Arrow Left Outer point
+                                            <<QPoint(aMuxerDataLabel.x()+5 ,aMuxerDataLabel.y()-(arrowHDepth-5))    // Arrow Left Inner point
+                                            // Remainder of Foot
+                                            <<QPoint(aMuxerDataLabel.x()+5,EOMuxerDataLabel.bottom()+20) // Pivot between arrow left side and lower horizontal leg
+                                            <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2-5,EOMuxerDataLabel.bottom()+20) // Pivot between lower horizontal leg and start
                                             );
 
 const QPolygon AMuxBus              = QPolygon(QVector<QPoint>()
-                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2-5,aMuxerDataLabel.y()+aMuxerDataLabel.height()) //Upper Left Corner
-                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2+5,aMuxerDataLabel.y()+aMuxerDataLabel.height()) //Upper Right Corner
-                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2+5,ALUPoly.boundingRect().y()-(arrowHDepth-5)) //Arrow Inner Right Edge
-                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2+10,ALUPoly.boundingRect().y()-(arrowHDepth-5)) //Arrow Outer Right Edge
-                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2,ALUPoly.boundingRect().y()-arrowHOffset) //Arrow Outer Right Edge
-                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2-10,ALUPoly.boundingRect().y()-(arrowHDepth-5)) //Arrow Outer Left Edge
-                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2-5,ALUPoly.boundingRect().y()-(arrowHDepth-5)) //Arrow Inner Left Edge
+                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2-5,aMuxerDataLabel.y()+aMuxerDataLabel.height())   //Foot Upper Left point
+                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2+5,aMuxerDataLabel.y()+aMuxerDataLabel.height())   //Upper Right point
+                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2+5,ALUPoly.boundingRect().y()-(arrowHDepth-5))     //Arrow Right Inner point
+                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2+10,ALUPoly.boundingRect().y()-(arrowHDepth-5))    //Arrow Right Outer point
+                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2,ALUPoly.boundingRect().y()-arrowHOffset)          //Arrow Middle point
+                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2-10,ALUPoly.boundingRect().y()-(arrowHDepth-5))    //Arrow Left Outer point
+                                               <<QPoint(aMuxerDataLabel.x()+aMuxerDataLabel.width()/2-5,ALUPoly.boundingRect().y()-(arrowHDepth-5))     //Arrow Left Inner point
                                                );
 
 // registers
@@ -392,101 +399,101 @@ const QRect m3RegLabel                      = OneByteShapes::m3RegLabel;
 const QRect m4RegLabel                      = OneByteShapes::m4RegLabel;
 const QRect m5RegLabel                      = OneByteShapes::m5RegLabel;
 const QPolygon ABus = QPolygon(QVector<QPoint>()
-                               << QPoint(aMuxerDataLabel.right()-15,RegBank.bottom()+1) //Top left corner of register foot
-                               << QPoint(aMuxerDataLabel.right()-5,RegBank.bottom()+1) //Top right corner of register foot;
-                               << QPoint(aMuxerDataLabel.right()-5,aMuxerDataLabel.y()-(arrowHDepth-5)) //AMux Arrow Right Inner point
-                               << QPoint(aMuxerDataLabel.right()-0,aMuxerDataLabel.y()-(arrowHDepth-5)) //AMux Arrow Right Outer point
-                               << QPoint(aMuxerDataLabel.right()-10,aMuxerDataLabel.y()-arrowHOffset) //AMux Arrow Middle point
-                               << QPoint(aMuxerDataLabel.right()-20,aMuxerDataLabel.y()-(arrowHDepth-5)) //AMux Arrow Left Outer point
-                               << QPoint(aMuxerDataLabel.right()-15,aMuxerDataLabel.y()-(arrowHDepth-5)) //AMux Arrow Left Inner point
-                               << QPoint(aMuxerDataLabel.right()-15,MARMuxerDataLabel.bottom()-5) //Pivot between AMUX arrow left point and MARMux Inner Bottom Edge
-                               << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.bottom()-5) //MARMux Arrow Bottom Inner point
-                               << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.bottom()-0) //MARMux Arrow Bottom Outer point
-                               << QPoint(MARMuxerDataLabel.right()+(arrowHOffset),MARMuxerDataLabel.bottom()-10) //MARMux Arrow Middle point
-                               << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.bottom()-20) //MARMux Arrow Top Outer point
-                               << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.bottom()-15) //MARMux Arrow Top Inner point
-                               << QPoint(aMuxerDataLabel.right()-15,MARMuxerDataLabel.bottom()-15) //Pivot between MARMux arrow top and register top left foot
+                               << QPoint(aMuxerDataLabel.right()-15,RegBank.bottom()+1) // Top left corner of register foot
+                               << QPoint(aMuxerDataLabel.right()-5,RegBank.bottom()+1) // Top right corner of register foot;
+                               << QPoint(aMuxerDataLabel.right()-5,aMuxerDataLabel.y()-(arrowHDepth-5)) // AMux Arrow Right Inner point
+                               << QPoint(aMuxerDataLabel.right()-0,aMuxerDataLabel.y()-(arrowHDepth-5)) // AMux Arrow Right Outer point
+                               << QPoint(aMuxerDataLabel.right()-10,aMuxerDataLabel.y()-arrowHOffset) // AMux Arrow Middle point
+                               << QPoint(aMuxerDataLabel.right()-20,aMuxerDataLabel.y()-(arrowHDepth-5)) // AMux Arrow Left Outer point
+                               << QPoint(aMuxerDataLabel.right()-15,aMuxerDataLabel.y()-(arrowHDepth-5)) // AMux Arrow Left Inner point
+                               << QPoint(aMuxerDataLabel.right()-15,MARMuxerDataLabel.bottom()-5) // Pivot between AMUX arrow left point and MARMux Inner Bottom Edge
+                               << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.bottom()-5) // MARMux Arrow Bottom Inner point
+                               << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.bottom()-0) // MARMux Arrow Bottom Outer point
+                               << QPoint(MARMuxerDataLabel.right()+(arrowHOffset),MARMuxerDataLabel.bottom()-10) // MARMux Arrow Middle point
+                               << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.bottom()-20) // MARMux Arrow Top Outer point
+                               << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.bottom()-15) // MARMux Arrow Top Inner point
+                               << QPoint(aMuxerDataLabel.right()-15,MARMuxerDataLabel.bottom()-15) // Pivot between MARMux arrow top and register top left foot
                                );
 const QPolygon BBus = QPolygon(QVector<QPoint>()
                               << QPoint(ALUUpperRightLineMidpoint-5,RegBank.bottom()+1) //Top left corner of register foot
                               << QPoint(ALUUpperRightLineMidpoint+5,RegBank.bottom()+1) //Top right corner of register foot
                               << QPoint(ALUUpperRightLineMidpoint+5,MARMuxerDataLabel.y()+5) //Pivot between register foor and right output
-                              << QPoint(BBusRightArrowTipX-(arrowHDepth-5), MARMuxerDataLabel.y()+5) //Right Out Arrow Top Inner point
-                              << QPoint(BBusRightArrowTipX-(arrowHDepth-5),MARMuxerDataLabel.y()+0) //Right Out Arrow Top Outer point
-                              << QPoint(BBusRightArrowTipX-(arrowHOffset),MARMuxerDataLabel.y()+10) //Right Out Arrow Middle point
-                              << QPoint(BBusRightArrowTipX-(arrowHDepth-5),MARMuxerDataLabel.y()+20) //Right Out Arrow Botton Outer point
-                              << QPoint(BBusRightArrowTipX-(arrowHDepth-5),MARMuxerDataLabel.y()+15) //Right Out Arrow Bottom Inner point
-                              << QPoint(ALUUpperRightLineMidpoint+5,MARMuxerDataLabel.y()+15) //Pivot between right out arrow and alu arrow
-                              << QPoint(ALUUpperRightLineMidpoint+5,ALUPoly.boundingRect().y()-(arrowHDepth-5)) //ALU Arrow Right Inner point
-                              << QPoint(ALUUpperRightLineMidpoint+10,ALUPoly.boundingRect().y()-(arrowHDepth-5)) //ALU Arrow Right Outer point
-                              << QPoint(ALUUpperRightLineMidpoint+0,ALUPoly.boundingRect().y()-(arrowHOffset)) //ALU Arrow Middle point
-                              << QPoint(ALUUpperRightLineMidpoint-10,ALUPoly.boundingRect().y()-(arrowHDepth-5)) //ALU Arrow Left Outer point
-                              << QPoint(ALUUpperRightLineMidpoint-5,ALUPoly.boundingRect().y()-(arrowHDepth-5)) //ALU Arrow Left Inner point
-                              << QPoint(ALUUpperRightLineMidpoint-5,MARMuxerDataLabel.y()+15) //Pivot between ALU arrow and MARMux Arrow
-                              << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.y()+15) //MARMux Arrow Bottom Inner point
-                              << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.y()+20) //MARMux Arrow Bottom Outer point
-                              << QPoint(MARMuxerDataLabel.right()+(arrowHOffset),MARMuxerDataLabel.y()+10) //MARMux Arrow Middle point
-                              << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.y()+0) //MARMux Arrow Top Outer point
-                              << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.y()+5) //MARMux Arrow Top Inner point
-                              << QPoint(ALUUpperRightLineMidpoint-5,MARMuxerDataLabel.y()+5) //Pivot between MARMux and register foot
+                              //<< QPoint(BBusRightArrowTipX-(arrowHDepth-5), MARMuxerDataLabel.y()+5) // Right Out Arrow Top Inner point
+                              //<< QPoint(BBusRightArrowTipX-(arrowHDepth-5),MARMuxerDataLabel.y()+0) // Right Out Arrow Top Outer point
+                              //<< QPoint(BBusRightArrowTipX-(arrowHOffset),MARMuxerDataLabel.y()+10) // Right Out Arrow Middle point
+                              //<< QPoint(BBusRightArrowTipX-(arrowHDepth-5),MARMuxerDataLabel.y()+20) // Right Out Arrow Botton Outer point
+                              //<< QPoint(BBusRightArrowTipX-(arrowHDepth-5),MARMuxerDataLabel.y()+15) // Right Out Arrow Bottom Inner point
+                              //<< QPoint(ALUUpperRightLineMidpoint+5,MARMuxerDataLabel.y()+15) // Pivot between right out arrow and alu arrow
+                              << QPoint(ALUUpperRightLineMidpoint+5,ALUPoly.boundingRect().y()-(arrowHDepth-5)) // ALU Arrow Right Inner point
+                              << QPoint(ALUUpperRightLineMidpoint+10,ALUPoly.boundingRect().y()-(arrowHDepth-5)) // ALU Arrow Right Outer point
+                              << QPoint(ALUUpperRightLineMidpoint+0,ALUPoly.boundingRect().y()-(arrowHOffset)) // ALU Arrow Middle point
+                              << QPoint(ALUUpperRightLineMidpoint-10,ALUPoly.boundingRect().y()-(arrowHDepth-5)) // ALU Arrow Left Outer point
+                              << QPoint(ALUUpperRightLineMidpoint-5,ALUPoly.boundingRect().y()-(arrowHDepth-5)) // ALU Arrow Left Inner point
+                              << QPoint(ALUUpperRightLineMidpoint-5,MARMuxerDataLabel.y()+15) // Pivot between ALU arrow and MARMux Arrow
+                              << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.y()+15) // MARMux Arrow Bottom Inner point
+                              << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.y()+20) // MARMux Arrow Bottom Outer point
+                              << QPoint(MARMuxerDataLabel.right()+(arrowHOffset),MARMuxerDataLabel.y()+10) // MARMux Arrow Middle point
+                              << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.y()+0) // MARMux Arrow Top Outer point
+                              << QPoint(MARMuxerDataLabel.right()+(arrowHDepth-5),MARMuxerDataLabel.y()+5) // MARMux Arrow Top Inner point
+                              << QPoint(ALUUpperRightLineMidpoint-5,MARMuxerDataLabel.y()+5) // Pivot between MARMux and register foot
                                );
 const QPolygon CBus = QPolygon(QVector<QPoint>()
-                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2+5,cMuxerLabel.y()) //CMux Right foot
-                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,cMuxerLabel.y()) //CMux Left foot
-                               //Branch off to MDREven
-                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+60) //Pivot between CMux foot and MDRE lower Leg
-                               <<QPoint(MDREMuxerDataLabel.right()-15,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+60) //Pivot between MDRE lower leg and MDRE left arrow
-                               <<QPoint(MDREMuxerDataLabel.right()-15,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Left Inner Point
-                               <<QPoint(MDREMuxerDataLabel.right()-20,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Left Outer Point
-                               <<QPoint(MDREMuxerDataLabel.right()-10,MDREMuxerDataLabel.bottom()+(arrowHOffset)) //MDREMux Arrow Middle Point
-                               <<QPoint(MDREMuxerDataLabel.right()-0,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Right Outer Point
-                               <<QPoint(MDREMuxerDataLabel.right()-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Right Inner Point
-                               <<QPoint(MDREMuxerDataLabel.right()-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+50) //Pivot between MDRE right arrow and MDRE upper leg
-                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+50) //Pivot between MDRE upper leg and leg upwards
-                               //Branch off to MDROdd
-                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+20) //Pivot between CMux foot and MDRE lower Leg
-                               <<QPoint(MDROMuxerDataLabel.right()-15,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+20) //Pivot between MDRE lower leg and MDRE left arrow
-                               <<QPoint(MDROMuxerDataLabel.right()-15,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Left Inner Point
-                               <<QPoint(MDROMuxerDataLabel.right()-20,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Left Outer Point
-                               <<QPoint(MDROMuxerDataLabel.right()-10,MDROMuxerDataLabel.bottom()+(arrowHOffset)) //MDREMux Arrow Middle Point
-                               <<QPoint(MDROMuxerDataLabel.right()-0,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Right Outer Point
-                               <<QPoint(MDROMuxerDataLabel.right()-5,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Right Inner Point
-                               <<QPoint(MDROMuxerDataLabel.right()-5,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+10) //Pivot between MDRE right arrow and MDRE upper leg
-                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+10) //Pivot between MDRE upper leg and leg upwards
-                               //Resume path to register bank's arrow
-                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,RegBank.bottom()+(arrowHDepth-5))//Register Arrow Left Inner Point
-                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-10,RegBank.bottom()+(arrowHDepth-5))//Register Arrow Left Outer Point
-                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2+0,RegBank.bottom()+(arrowHOffset))//Register Arrow Middle Point
-                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2+10,RegBank.bottom()+(arrowHDepth-5))//Register Arrow Right Outer Point
-                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2+5,RegBank.bottom()+(arrowHDepth-5))//Register Arrow Right Inner Point
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2+5,cMuxerLabel.y()) // CMux Right foot
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,cMuxerLabel.y()) // CMux Left foot
+                               // Branch off to MDREven
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+CBusToMDREMuxLength) // Pivot between CMux foot and MDRE lower Leg
+                               <<QPoint(MDREMuxerDataLabel.right()-15,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+CBusToMDREMuxLength) // Pivot between MDRE lower leg and MDRE left arrow
+                               <<QPoint(MDREMuxerDataLabel.right()-15,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) // MDREMux Arrow Left Inner Point
+                               <<QPoint(MDREMuxerDataLabel.right()-20,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) // MDREMux Arrow Left Outer Point
+                               <<QPoint(MDREMuxerDataLabel.right()-10,MDREMuxerDataLabel.bottom()+(arrowHOffset)) // MDREMux Arrow Middle Point
+                               <<QPoint(MDREMuxerDataLabel.right()-0,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) // MDREMux Arrow Right Outer Point
+                               <<QPoint(MDREMuxerDataLabel.right()-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) // MDREMux Arrow Right Inner Point
+                               <<QPoint(MDREMuxerDataLabel.right()-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+CBusToMDREMuxLength-10) // Pivot between MDRE right arrow and MDRE upper leg
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+CBusToMDREMuxLength-10) // Pivot between MDRE upper leg and leg upwards
+                               // Branch off to MDROdd
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+20) // Pivot between CMux foot and MDRE lower Leg
+                               <<QPoint(MDROMuxerDataLabel.right()-15,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+20) // Pivot between MDRE lower leg and MDRE left arrow
+                               <<QPoint(MDROMuxerDataLabel.right()-15,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) // MDREMux Arrow Left Inner Point
+                               <<QPoint(MDROMuxerDataLabel.right()-20,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) // MDREMux Arrow Left Outer Point
+                               <<QPoint(MDROMuxerDataLabel.right()-10,MDROMuxerDataLabel.bottom()+(arrowHOffset)) // MDREMux Arrow Middle Point
+                               <<QPoint(MDROMuxerDataLabel.right()-0,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) // MDREMux Arrow Right Outer Point
+                               <<QPoint(MDROMuxerDataLabel.right()-5,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) // MDREMux Arrow Right Inner Point
+                               <<QPoint(MDROMuxerDataLabel.right()-5,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+10) // Pivot between MDRE right arrow and MDRE upper leg
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+10) // Pivot between MDRE upper leg and leg upwards
+                               // Resume path to register bank's arrow
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,RegBank.bottom()+(arrowHDepth-5))// Register Arrow Left Inner Point
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-10,RegBank.bottom()+(arrowHDepth-5))// Register Arrow Left Outer Point
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2+0,RegBank.bottom()+(arrowHOffset))// Register Arrow Middle Point
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2+10,RegBank.bottom()+(arrowHDepth-5))// Register Arrow Right Outer Point
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2+5,RegBank.bottom()+(arrowHDepth-5))// Register Arrow Right Inner Point
                                );
 const QPolygon AddrArrow                    = OneByteShapes::AddrArrow;
 //const QPolygon DataToMDRMuxBus;
 const QPolygon DataToMDROMuxBus = QPolygon(QVector<QPoint>()
-                                           // foot:
-                                           << QPoint(MDROMuxerDataLabel.x()+15, MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+18) //Point between vertical right leg and lower horizontal leg
-                                           << QPoint(80,  MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+18) //Lower left corner on bus
-                                           << QPoint(80,  MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+8) //Upper left corner on bus
-                                           << QPoint(MDROMuxerDataLabel.x()+5, MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+8) //Point between vertical left leg and upper horizontal leg
-                                           // arrowhead:
-                                           << QPoint(MDROMuxerDataLabel.x()+5, MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) //arrow inner left edge
-                                           << QPoint(MDROMuxerDataLabel.x()+0, MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) //arrow outer left edge
-                                           << QPoint(MDROMuxerDataLabel.x()+10, MDROMuxerDataLabel.bottom()+arrowHOffset) //arrow midpoint
-                                           << QPoint(MDROMuxerDataLabel.x()+20, MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) //arrow right outer edge
-                                           << QPoint(MDROMuxerDataLabel.x()+15, MDROMuxerDataLabel.bottom()+(arrowHDepth-5))); //arrow inner left edge
+                                           // Foot:
+                                           << QPoint(MDROMuxerDataLabel.x()+15, MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+18) // Point between vertical right leg and lower horizontal leg
+                                           << QPoint(80,  MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+18) // DataBus Foot Bottom point
+                                           << QPoint(80,  MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+8) // DataBus Foot Top point
+                                           << QPoint(MDROMuxerDataLabel.x()+5, MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+8) // Point between vertical left leg and upper horizontal leg
+                                           // Arrowhead:
+                                           << QPoint(MDROMuxerDataLabel.x()+5, MDROMuxerDataLabel.bottom()+arrowHDepth-5) // Arrow Left Inner point
+                                           << QPoint(MDROMuxerDataLabel.x()+0, MDROMuxerDataLabel.bottom()+arrowHDepth-5) // Arrow Left Outer point
+                                           << QPoint(MDROMuxerDataLabel.x()+10, MDROMuxerDataLabel.bottom()+arrowHOffset) // Arrow Middle point
+                                           << QPoint(MDROMuxerDataLabel.x()+20, MDROMuxerDataLabel.bottom()+arrowHDepth-5)  // Arrow Right Outer point
+                                           << QPoint(MDROMuxerDataLabel.x()+15, MDROMuxerDataLabel.bottom()+arrowHDepth-5)); // Arrow Right Inner point
 
 const QPolygon DataToMDREMuxBus = QPolygon(QVector<QPoint>()
-                                           // foot:
-                                           << QPoint(MDREMuxerDataLabel.x()+15, MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+18) //Point between vertical right leg and lower horizontal leg
-                                           << QPoint(80,  MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+18) //Lower left corner on bus
-                                           << QPoint(80,  MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+8) //Upper left corner on bus
-                                           << QPoint(MDREMuxerDataLabel.x()+5, MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+8) //Point between vertical left leg and upper horizontal leg
-                                           // arrowhead:
-                                           << QPoint(MDREMuxerDataLabel.x()+5, MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //arrow inner left edge
-                                           << QPoint(MDREMuxerDataLabel.x()+0, MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //arrow outer left edge
-                                           << QPoint(MDREMuxerDataLabel.x()+10, MDREMuxerDataLabel.bottom()+arrowHOffset) //arrow midpoint
-                                           << QPoint(MDREMuxerDataLabel.x()+20, MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //arrow right outer edge
-                                           << QPoint(MDREMuxerDataLabel.x()+15, MDREMuxerDataLabel.bottom()+(arrowHDepth-5))); //arrow inner left edge
+                                           // Foot:
+                                           << QPoint(MDREMuxerDataLabel.x()+15, MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+18) // Pivot between vertical right leg and lower horizontal leg
+                                           << QPoint(80,  MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+18) // DataBus Foot Bottom point
+                                           << QPoint(80,  MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+8)  // DataBus Foot Top point
+                                           << QPoint(MDREMuxerDataLabel.x()+5, MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+8)// Pivot between vertical left leg and upper horizontal leg
+                                           // Arrowhead:
+                                           << QPoint(MDREMuxerDataLabel.x()+5, MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) // Arrow Left Inner point
+                                           << QPoint(MDREMuxerDataLabel.x()+0, MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) // Arrow Left Outer point
+                                           << QPoint(MDREMuxerDataLabel.x()+10, MDREMuxerDataLabel.bottom()+arrowHOffset)   // Arrow Middle point
+                                           << QPoint(MDREMuxerDataLabel.x()+20, MDREMuxerDataLabel.bottom()+arrowHDepth-5)  // Arrow Right Outer point
+                                           << QPoint(MDREMuxerDataLabel.x()+15, MDREMuxerDataLabel.bottom()+arrowHDepth-5));// Arrow Right Inner point
 //const QPolygon MDRToDataBus;
 const QPolygon MDROToDataBus = QPolygon(QVector<QPoint>()
                                         << QPoint(MDROLabel.x(), MDROLabel.y()+MDROLabel.height()/2-5)                      //Top Right Corner
@@ -498,63 +505,63 @@ const QPolygon MDROToDataBus = QPolygon(QVector<QPoint>()
                                         << QPoint(MDROLabel.x(), MDROLabel.y()+MDROLabel.height()/2+5));                    //Bottom Right Corner
 
 const QPolygon MDREToDataBus = QPolygon(QVector<QPoint>()
-                                        << QPoint(MDRELabel.x(), MDRELabel.y()+MDRELabel.height()/2-5)                      //Top Right Corner
-                                        << QPoint(DataBus.x()+DataBus.width()+13, MDRELabel.y()+MDRELabel.height()/2-5)     //Arrow Inner upper point
-                                        << QPoint(DataBus.x()+DataBus.width()+13, MDRELabel.y()+MDRELabel.height()/2-10)    //Arrow Outer Upper point
-                                        << QPoint(DataBus.x()+DataBus.width()+3, MDRELabel.y()+MDRELabel.height()/2)        //Arrow middle
-                                        << QPoint(DataBus.x()+DataBus.width()+13, MDRELabel.y()+MDRELabel.height()/2+10)    //Arrow Outer Lower Point
-                                        << QPoint(DataBus.x()+DataBus.width()+13, MDRELabel.y()+MDRELabel.height()/2+5)     //Arrow Inner Lower Point
-                                        << QPoint(MDRELabel.x(), MDRELabel.y()+MDRELabel.height()/2+5));                    //Bottom Right Corner
+                                        << QPoint(MDRELabel.x(), MDRELabel.y()+MDRELabel.height()/2-5)                      // Foot Top point
+                                        << QPoint(DataBus.x()+DataBus.width()+13, MDRELabel.y()+MDRELabel.height()/2-5)     // Arrow Top Inner point
+                                        << QPoint(DataBus.x()+DataBus.width()+13, MDRELabel.y()+MDRELabel.height()/2-10)    // Arrow Top Outer point
+                                        << QPoint(DataBus.x()+DataBus.width()+3, MDRELabel.y()+MDRELabel.height()/2)        // Arrow middle point
+                                        << QPoint(DataBus.x()+DataBus.width()+13, MDRELabel.y()+MDRELabel.height()/2+10)    // Arrow Botton Outer point
+                                        << QPoint(DataBus.x()+DataBus.width()+13, MDRELabel.y()+MDRELabel.height()/2+5)     // Arrow Bottom Inner point
+                                        << QPoint(MDRELabel.x(), MDRELabel.y()+MDRELabel.height()/2+5));                    // Foot Bottom point
 const QPolygon MDREToEOMuxBus = QPolygon(QVector<QPoint>()
-                                         << QPoint(MDRELabel.right()+1,MDRELabel.y()+MDRELabel.height()/2 - 5) //MDRE Top Point
-                                         << QPoint(MDRELabel.right()+1,MDRELabel.y()+MDRELabel.height()/2 + 5) //MDRE Bottom Point
-                                         << QPoint(EOMuxerDataLabel.x()+5,MDRELabel.y()+MDRELabel.height()/2 + 5) //Pivot between MDRE bottom and EOMux bottom
-                                         << QPoint(EOMuxerDataLabel.x()+5,EOMuxerDataLabel.y()-(arrowHDepth-5)) //EOMux Arrow Inner Left Edge
-                                         << QPoint(EOMuxerDataLabel.x()+0,EOMuxerDataLabel.y()-(arrowHDepth-5)) //EOMux Arrow Outer Left Edge
-                                         << QPoint(EOMuxerDataLabel.x()+10,EOMuxerDataLabel.y()-(arrowHOffset)) //EOMux Arrow Midpoint
-                                         << QPoint(EOMuxerDataLabel.x()+20,EOMuxerDataLabel.y()-(arrowHDepth-5)) //EOMux Arrow Outer Right Edge
-                                         << QPoint(EOMuxerDataLabel.x()+15,EOMuxerDataLabel.y()-(arrowHDepth-5)) //EOMux Arrow Inner Right Edge
-                                         << QPoint(EOMuxerDataLabel.x()+15,MARMuxerDataLabel.bottom()+(arrowHDepth-5)) //MARMux Arrow Inner Right Edge
-                                         << QPoint(EOMuxerDataLabel.x()+20,MARMuxerDataLabel.bottom()+(arrowHDepth-5)) //MARMux Arrow Outer Right Edge
-                                         << QPoint(EOMuxerDataLabel.x()+10,MARMuxerDataLabel.bottom()+(arrowHOffset)) //MARMux Arrow Midpoint
-                                         << QPoint(EOMuxerDataLabel.x()+0,MARMuxerDataLabel.bottom()+(arrowHDepth-5)) //MARMux Arrow Outer Left Edge
-                                         << QPoint(EOMuxerDataLabel.x()+5,MARMuxerDataLabel.bottom()+(arrowHDepth-5)) //MARMux Arrow Inner Left Edge
-                                         << QPoint(EOMuxerDataLabel.x()+5,MDRELabel.y()+MDRELabel.height()/2 -5) //Pivot between MARMux bottom and MDRE top
+                                         << QPoint(MDRELabel.right()+1,MDRELabel.y()+MDRELabel.height()/2 - 5)              // MDRE Foot Top point
+                                         << QPoint(MDRELabel.right()+1,MDRELabel.y()+MDRELabel.height()/2 + 5)              // MDRE Foot Bottom point
+                                         << QPoint(EOMuxerDataLabel.x()+5,MDRELabel.y()+MDRELabel.height()/2 + 5)           // Pivot between MDRE bottom and EOMux bottom
+                                         << QPoint(EOMuxerDataLabel.x()+5,EOMuxerDataLabel.y()-(arrowHDepth-5))             // EOMux Arrow Left Inner point
+                                         << QPoint(EOMuxerDataLabel.x()+0,EOMuxerDataLabel.y()-(arrowHDepth-5))             // EOMux Arrow Left Outer point
+                                         << QPoint(EOMuxerDataLabel.x()+10,EOMuxerDataLabel.y()-(arrowHOffset))             // EOMux Arrow Middle point
+                                         << QPoint(EOMuxerDataLabel.x()+20,EOMuxerDataLabel.y()-(arrowHDepth-5))            // EOMux Arrow Right Outer point
+                                         << QPoint(EOMuxerDataLabel.x()+15,EOMuxerDataLabel.y()-(arrowHDepth-5))            // EOMux Arrow Right Inner point
+                                         << QPoint(EOMuxerDataLabel.x()+15,MARMuxerDataLabel.bottom()+(arrowHDepth-5))      // MARMux Arrow Right Inner point
+                                         << QPoint(EOMuxerDataLabel.x()+20,MARMuxerDataLabel.bottom()+(arrowHDepth-5))      // MARMux Arrow Right Outer point
+                                         << QPoint(EOMuxerDataLabel.x()+10,MARMuxerDataLabel.bottom()+(arrowHOffset))       // MARMux Arrow Middle point
+                                         << QPoint(EOMuxerDataLabel.x()+0,MARMuxerDataLabel.bottom()+(arrowHDepth-5))       // MARMux Arrow Left Outer point
+                                         << QPoint(EOMuxerDataLabel.x()+5,MARMuxerDataLabel.bottom()+(arrowHDepth-5))       // MARMux Arrow Left Inner point
+                                         << QPoint(EOMuxerDataLabel.x()+5,MDRELabel.y()+MDRELabel.height()/2 -5)            // Pivot between MARMux bottom and MDRE top
                                          );
 const QPolygon MDROToEOMuxBus = QPolygon(QVector<QPoint>()
-                                         << QPoint(MDROLabel.right()+1,MDROLabel.y()+MDROLabel.height()/2 - 5) //MDRE Top Point
-                                         << QPoint(MDROLabel.right()+1,MDROLabel.y()+MDROLabel.height()/2 + 5) //MDRE Bottom Point
-                                         << QPoint(EOMuxerDataLabel.right()-15,MDROLabel.y()+MDROLabel.height()/2 + 5) //Pivot between MDRE bottom and EOMux bottom
-                                         << QPoint(EOMuxerDataLabel.right()-15,EOMuxerDataLabel.y()-(arrowHDepth-5)) //EOMux Arrow Inner Left Edge
-                                         << QPoint(EOMuxerDataLabel.right()-20,EOMuxerDataLabel.y()-(arrowHDepth-5)) //EOMux Arrow Outer Left Edge
-                                         << QPoint(EOMuxerDataLabel.right()-10,EOMuxerDataLabel.y()-(arrowHOffset)) //EOMux Arrow Midpoint
-                                         << QPoint(EOMuxerDataLabel.right()-0,EOMuxerDataLabel.y()-(arrowHDepth-5)) //EOMux Arrow Outer Right Edge
-                                         << QPoint(EOMuxerDataLabel.right()-5,EOMuxerDataLabel.y()-(arrowHDepth-5)) //EOMux Arrow Inner Right Edge
-                                         << QPoint(EOMuxerDataLabel.right()-5,MARMuxerDataLabel.bottom()+(arrowHDepth-5)) //MARMux Arrow Inner Right Edge
-                                         << QPoint(EOMuxerDataLabel.right()+0,MARMuxerDataLabel.bottom()+(arrowHDepth-5)) //MARMux Arrow Outer Right Edge
-                                         << QPoint(EOMuxerDataLabel.right()-10,MARMuxerDataLabel.bottom()+(arrowHOffset)) //MARMux Arrow Midpoint
-                                         << QPoint(EOMuxerDataLabel.right()-20,MARMuxerDataLabel.bottom()+(arrowHDepth-5)) //MARMux Arrow Outer Left Edge
-                                         << QPoint(EOMuxerDataLabel.right()-15,MARMuxerDataLabel.bottom()+(arrowHDepth-5)) //MARMux Arrow Inner Left Edge
-                                         << QPoint(EOMuxerDataLabel.right()-15,MDROLabel.y()+MDROLabel.height()/2 -5) //Pivot between MARMux bottom and MDRE top
+                                         << QPoint(MDROLabel.right()+1,MDROLabel.y()+MDROLabel.height()/2 - 5)              // MDRO Foot Top point
+                                         << QPoint(MDROLabel.right()+1,MDROLabel.y()+MDROLabel.height()/2 + 5)              // MDRO Foot Bottom point
+                                         << QPoint(EOMuxerDataLabel.right()-15,MDROLabel.y()+MDROLabel.height()/2 + 5)      // Pivot between MDRE bottom and EOMux bottom
+                                         << QPoint(EOMuxerDataLabel.right()-15,EOMuxerDataLabel.y()-(arrowHDepth-5))        // EOMux Arrow Left Inner Edge
+                                         << QPoint(EOMuxerDataLabel.right()-20,EOMuxerDataLabel.y()-(arrowHDepth-5))        // EOMux Arrow Left Outer Edge
+                                         << QPoint(EOMuxerDataLabel.right()-10,EOMuxerDataLabel.y()-(arrowHOffset))         // EOMux Arrow Middle point
+                                         << QPoint(EOMuxerDataLabel.right()-0,EOMuxerDataLabel.y()-(arrowHDepth-5))         // EOMux Arrow Right Outer Edge
+                                         << QPoint(EOMuxerDataLabel.right()-5,EOMuxerDataLabel.y()-(arrowHDepth-5))         // EOMux Arrow Right Inner Edge
+                                         << QPoint(EOMuxerDataLabel.right()-5,MARMuxerDataLabel.bottom()+(arrowHDepth-5))   // MARMux Arrow Right Inner Edge
+                                         << QPoint(EOMuxerDataLabel.right()+0,MARMuxerDataLabel.bottom()+(arrowHDepth-5))   // MARMux Arrow Right Outer Edge
+                                         << QPoint(EOMuxerDataLabel.right()-10,MARMuxerDataLabel.bottom()+(arrowHOffset))   // MARMux Arrow Middle point
+                                         << QPoint(EOMuxerDataLabel.right()-20,MARMuxerDataLabel.bottom()+(arrowHDepth-5))  // MARMux Arrow Left Outer Edge
+                                         << QPoint(EOMuxerDataLabel.right()-15,MARMuxerDataLabel.bottom()+(arrowHDepth-5))  // MARMux Arrow Left Inner Edge
+                                         << QPoint(EOMuxerDataLabel.right()-15,MDROLabel.y()+MDROLabel.height()/2 -5)       // Pivot between MARMux bottom and MDRE top
                                          );
 //const QPolygon MDRMuxOutBus;
 const QPolygon MDROMuxOutBus = QPolygon(QVector<QPoint>()
-                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2-5, MDROMuxerDataLabel.y()) //Bottom Left Corner
-                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2-5, MDROMuxerDataLabel.y() - 7) //Arrow Inner Left Edge
-                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2-10, MDROMuxerDataLabel.y() - 7) //Arrow  Outer left Edge
-                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2, MDROMuxerDataLabel.y() - 17) //Arrow Point
-                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2+10, MDROMuxerDataLabel.y() - 7) //Arrow Outer Right Edge
-                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2+5, MDROMuxerDataLabel.y() - 7) //Arrow Inner Right Edge
-                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2+5, MDROMuxerDataLabel.y())); //Bottom Right Corner
+                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2-5, MDROMuxerDataLabel.y())        //Foot Left point
+                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2-5, MDROMuxerDataLabel.y() - 7)    //Arrow Left Inner point
+                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2-10, MDROMuxerDataLabel.y() - 7)   //Arrow Left Outer point
+                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2, MDROMuxerDataLabel.y() - 17)     //Arrow Middle point
+                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2+10, MDROMuxerDataLabel.y() - 7)   //Arrow Right Outer point
+                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2+5, MDROMuxerDataLabel.y() - 7)    //Arrow Right Inner point
+                                        << QPoint(MDROMuxerDataLabel.x()+MDROMuxerDataLabel.width()/2+5, MDROMuxerDataLabel.y()));      //Foot Right point
 
 const QPolygon MDREMuxOutBus = QPolygon(QVector<QPoint>()
-                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2-5, MDREMuxerDataLabel.y()) //Bottom Left Corner
-                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2-5, MDREMuxerDataLabel.y() - 7) //Arrow Inner Left Edge
-                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2-10, MDREMuxerDataLabel.y() - 7) //Arrow  Outer left Edge
-                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2, MDREMuxerDataLabel.y() - 17) //Arrow Point
-                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2+10, MDREMuxerDataLabel.y() - 7) //Arrow Outer Right Edge
-                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2+5, MDREMuxerDataLabel.y() - 7) //Arrow Inner Right Edge
-                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2+5, MDREMuxerDataLabel.y())); //Bottom Right Corner
+                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2-5, MDREMuxerDataLabel.y())        // Foot Left point
+                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2-5, MDREMuxerDataLabel.y() - 7)    // Arrow Left Inner point
+                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2-10, MDREMuxerDataLabel.y() - 7)   // Arrow  Outer left point
+                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2, MDREMuxerDataLabel.y() - 17)     // Arrow Middle point
+                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2+10, MDREMuxerDataLabel.y() - 7)   // Arrow Right Outer point
+                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2+5, MDREMuxerDataLabel.y() - 7)    // Arrow Right Inner point
+                                        << QPoint(MDREMuxerDataLabel.x()+MDREMuxerDataLabel.width()/2+5, MDREMuxerDataLabel.y()));      // Foot Right point
 
 
 

--- a/shapes_two_byte_data_bus.h
+++ b/shapes_two_byte_data_bus.h
@@ -73,7 +73,7 @@ enum CommonPositions {
     ctrlInputX = 550 + controlOffsetX,
     interfaceRegsX = 175,               // x-center of MARB, MARA, ...
     combCircX = interfaceRegsX - iRegXOffset-20, //Combinational circuits need to be moved further left to fit.
-    combCircY = 142, //Memory Combinational circuits start at this height. Originally 132
+    combCircY = 152, //Memory Combinational circuits start at this height. Originally 132
     statusBitsX = 526,//476,
     BottomOfAlu=OneByteShapes::ALUBottomBound+aluOffsetY, //Y coordinate of the bottom of the ALU
     ALUUpperRightLineMidpoint=(OneByteShapes::ALUUpperRightLine_LeftPoint+OneByteShapes::ALUUpperRightLine_RightPoint)/2+controlOffsetX,
@@ -85,8 +85,8 @@ enum CommonPositions {
 enum CommonOffsets{
     AMuxYOffsetFromALUPoly=40,  //The number of pixels between AMux and the ALU Polygon
     MARMUXOffestFromMARA=25,    //Number of pixels between MARMux and (MARA, MARB) horizontally.
-    MARAOffsetFromMARB=70,      //Number of pixels vertically between MARA and MARB
-    MDREOffsetFromCombY=120,    //Number of pixels vertically between MDRO register and the combCircY origin.
+    MARAOffsetFromMARB=60,      //Number of pixels vertically between MARA and MARB
+    MDREOffsetFromCombY=110,    //Number of pixels vertically between MDRO register and the combCircY origin.
     MDRORegOffsetFromMDREMux=42,//Number of pixels vertically between MDROMux and MDREMux
     MDRRegOffsetFromMDRMux=20,  //Number of pixels between the bottom of MDRO,MDRE registers and the top of MDROMux, MDREMux
     SCKYOffsetFromALU=43,       //Number of pixel between bottom of ALU and top of SCk controls
@@ -147,17 +147,16 @@ const Arrow ASelect                 = Arrow(QVector<QPoint>() << QPoint(499, 91)
 const QRect MARMuxerDataLabel       = QRect((combCircX+dataLabelW)+MARMUXOffestFromMARA, combCircY, dataLabelH+MARAOffsetFromMARB, dataLabelH+MARAOffsetFromMARB); // 89 x 89 square from bottom of MARA to top of MARB
 const QRect MARMuxTristateLabel     = QRect(ctrlInputX, MARMuxerDataLabel.y()-28, labelTriW, labelTriH);
 const QRect MARMuxLabel             = QRect(ctrlLabelX, MARMuxTristateLabel.y(), labelW+20, labelH);
-const Arrow MARMuxSelect            = Arrow(QVector<QPoint>() << QPoint(MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2, MARMuxerDataLabel.y()-12),
+const Arrow MARMuxSelect            = Arrow(QVector<QPoint>() << QPoint(MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2-3, MARMuxerDataLabel.y()-12),
                                             QVector<QLine>()
-                                            << QLine(MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2+3, MARMuxerDataLabel.y()-4,
-                                                     MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2+3, MARMuxerDataLabel.y()-19)
-                                            << QLine(MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2+3, MARMuxTristateLabel.y()+9,
-                                                     326, MARMuxTristateLabel.y()+9)
-                                            << QLine(350, MARMuxTristateLabel.y()+9,
-                                                     ctrlInputX - 7, MARMuxTristateLabel.y()+9));
+                                            << QLine(MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2, MARMuxTristateLabel.y()+MARMuxTristateLabel.height()/2,
+                                                     MARMuxTristateLabel.x(), MARMuxTristateLabel.y()+MARMuxTristateLabel.height()/2) //Horizontal line from middle of MARMux to the tristate label
+                                            << QLine(MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2, MARMuxTristateLabel.y()+MARMuxTristateLabel.height()/2,
+                                                     MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2,MARMuxerDataLabel.y()-12) //Vertical line connecting the arrowhead to the horizontal line
+                                            );
 
 // MARCk and its control
-const QRect MARCkCheckbox           = QRect(ctrlInputX, 169, check2W, check2H);
+const QRect MARCkCheckbox           = QRect(ctrlInputX, MARMuxerDataLabel.y()+MARMuxerDataLabel.height()/2-check2H/2, check2W, check2H);
 const QRect MARALabel               = QRect(combCircX, combCircY+MARAOffsetFromMARB, dataLabelW, dataLabelH); // MARA register.
 const QRect MARBLabel               = QRect(combCircX, combCircY, dataLabelW, dataLabelH); // MARB register
 const Arrow MARCk                   = Arrow(QVector<QPoint>()
@@ -165,13 +164,13 @@ const Arrow MARCk                   = Arrow(QVector<QPoint>()
                                             << QPoint(combCircX+5*dataLabelW/7+7,combCircY+dataLabelH+3)
                                             << QPoint(combCircX+5*dataLabelW/7+7,combCircY+MARAOffsetFromMARB-11),
                                             QVector<QLine> ()
-                                            << QLine(428,177, 543,177)
-                                            << QLine(367,177, 416,177)
-                                            << QLine(291,177, 355,177)
-                                            << QLine(235-50,177, 279,177)
+                                            << QLine(MARMuxerDataLabel.right()+3,MARMuxerDataLabel.y()+MARMuxerDataLabel.height()/2,
+                                                     MARCkCheckbox.x(),MARMuxerDataLabel.y()+MARMuxerDataLabel.height()/2) //Horizontal line segment between MARMux and MARCk
+                                            << QLine(combCircX+5*dataLabelW/7+10,MARMuxerDataLabel.y()+MARMuxerDataLabel.height()/2,
+                                                     MARMuxerDataLabel.x(),MARMuxerDataLabel.y()+MARMuxerDataLabel.height()/2) //Horizontal line segment between MARMux and MAR{A,B}
                                             //The vertical lines intersecting MAR,MARB should be roughly 5/7 of the way down the circuits.
                                             << QLine(combCircX+5*dataLabelW/7+10,combCircY+dataLabelH+3,
-                                                     combCircX+5*dataLabelW/7+10,combCircY+MARAOffsetFromMARB-3));  //Vertical line at left end of MARck
+                                                     combCircX+5*dataLabelW/7+10,combCircY+MARAOffsetFromMARB-3));  //Vertical line at left end of MARCk
 // MARMux output busses
 const QPolygon MARMuxToMARABus = QPolygon(QVector<QPoint>()
                                         << QPoint(MARMuxerDataLabel.x(), MARALabel.y()+MARALabel.height()/2-5)               //Top Right Corner
@@ -193,39 +192,52 @@ const QPolygon MARMuxToMARBBus = QPolygon(QVector<QPoint>()
 
 // MDROdd, MDROCk and its control
 const QRect MDROLabel               = QRect(combCircX, combCircY+MDREOffsetFromCombY, dataLabelW, dataLabelH);
-const QRect MDROCkCheckbox          = QRect(ctrlInputX, MDROLabel.y()-20, checkW+10, checkH);
-const Arrow MDROck              = Arrow(QVector<QPoint>() << QPoint(MDROLabel.x()+MDROLabel.width()/2, MDROLabel.y()-12),
+const QRect MDROCkCheckbox          = QRect(ctrlInputX, MDROLabel.y()-25, checkW+10, checkH);
+const Arrow MDROck              = Arrow(QVector<QPoint>() << QPoint(MDROLabel.x()+MDROLabel.width()/2-3, MDROLabel.y()-12),
                                             QVector<QLine>()
-                                            << QLine(MDROLabel.x()+MDROLabel.width()/2+3, MDROLabel.y()-4,
-                                                     MDROLabel.x()+MDROLabel.width()/2+3, MDROLabel.y()-19)
-                                            << QLine(MDROLabel.x()+MDROLabel.width()/2+3, MDROCkCheckbox.y()+9,
-                                                     326, MDROCkCheckbox.y()+9)
-                                            << QLine(350, MDROCkCheckbox.y()+9,
-                                                     ctrlInputX - 7, MDROCkCheckbox.y()+9));
+                                        << QLine(MDROLabel.x()+MDROLabel.width()/2,MDROCkCheckbox.y()+MDROCkCheckbox.height()/2,
+                                                 MDROCkCheckbox.x(),MDROCkCheckbox.y()+MDROCkCheckbox.height()/2) //Horizontal line from MDRO checkbox to center of MDRO
+                                        << QLine(MDROLabel.x()+MDROLabel.width()/2,MDROCkCheckbox.y()+MDROCkCheckbox.height()/2,
+                                                 MDROLabel.x()+MDROLabel.width()/2, MDROLabel.y()-12) //Vertical line between arrowhead and horizontal line from checkbox
+                                        );
 
 // MDROMux and its control
 const QRect MDROMuxerDataLabel      = QRect(combCircX, MDROLabel.bottom()+MDRRegOffsetFromMDRMux, dataLabelW, dataLabelH);
-const QRect MDROMuxTristateLabel    = QRect(ctrlInputX, MDROMuxerDataLabel.y()-20, labelTriW, labelTriH);
+const QRect MDROMuxTristateLabel    = QRect(ctrlInputX, MDROMuxerDataLabel.y(), labelTriW, labelTriH);
 const QRect MDROMuxLabel            = QRect(ctrlLabelX, MDROMuxTristateLabel.y(), labelW+20, labelH);
 const Arrow MDROMuxSelect           = Arrow(QVector<QPoint>()
-                                            <<QPoint(MDROMuxerDataLabel.right(),MDROMuxTristateLabel.y()+MDROMuxTristateLabel.height()/2-3),
+                                            <<QPoint(MDROMuxerDataLabel.right()+5,MDROMuxTristateLabel.y()+MDROMuxTristateLabel.height()/2-3),
                                             QVector<QLine>()
                                             <<QLine(MDROMuxTristateLabel.x(),MDROMuxTristateLabel.y()+MDROMuxTristateLabel.height()/2,
-                                                    MDROMuxerDataLabel.right()+5,MDROMuxTristateLabel.y()+MDROMuxTristateLabel.height()/2));
+                                                    MDROMuxerDataLabel.right()+5,MDROMuxTristateLabel.y()+MDROMuxTristateLabel.height()/2) //Horizontal line between MDROMux and its tri state label
+                                            );
 
 // MDREven, MDRECk and its control
 const QRect MDRELabel               = QRect(combCircX, MDROMuxerDataLabel.bottom()+MDRORegOffsetFromMDREMux, dataLabelW, dataLabelH);
-const QRect MDRECkCheckbox          = QRect(ctrlInputX, MDRELabel.y()-20, checkW+10, checkH);
+const QRect MDRECkCheckbox          = QRect(ctrlInputX, MDRELabel.y()-30, checkW+10, checkH);
+const Arrow MDREck                  = Arrow(QVector<QPoint>()
+                                            <<QPoint(MDRELabel.x()+MDRELabel.width()/2-3, MDRELabel.y()-12),
+                                            QVector<QLine>()
+                                            << QLine(MDRECkCheckbox.x(),MDROMuxerDataLabel.bottom()+20,
+                                                     MDRELabel.x()+MDRELabel.width()/2,MDROMuxerDataLabel.bottom()+20) //Horizontal line from MDRECk to midpoint of MDREven
+                                            << QLine(MDRELabel.x()+MDRELabel.width()/2,MDROMuxerDataLabel.bottom()+20,
+                                                     MDRELabel.x()+MDRELabel.width()/2,MDRELabel.y()-12) //Vertical line connecting arrowhead and horizontal line segment
+                                            );
 
 // MDREMux and its control
 const QRect MDREMuxerDataLabel      = QRect(combCircX,MDRELabel.bottom()+MDRRegOffsetFromMDRMux, dataLabelW, dataLabelH);
-const QRect MDREMuxTristateLabel    = QRect(ctrlInputX, MDREMuxerDataLabel.y()-20, labelTriW, labelTriH);
+const QRect MDREMuxTristateLabel    = QRect(ctrlInputX, MDREMuxerDataLabel.y()-30, labelTriW, labelTriH);
 const QRect MDREMuxLabel            = QRect(ctrlLabelX, MDREMuxTristateLabel.y(), labelW+20, labelH);
 const Arrow MDREMuxSelect           = Arrow(QVector<QPoint>()
-                                            << QPoint(MDREMuxerDataLabel.right(),MDREMuxTristateLabel.y()+MDREMuxTristateLabel.height()/2-3),
+                                            << QPoint(MDREMuxerDataLabel.right()+5,MDREMuxerDataLabel.y()+MDREMuxerDataLabel.height()/2-3),
                                             QVector<QLine>()
-                                            <<QLine(MDREMuxTristateLabel.x(),MDREMuxTristateLabel.y()+MDREMuxTristateLabel.height()/2,
-                                                    MDREMuxerDataLabel.right()+5,MDREMuxTristateLabel.y()+MDREMuxTristateLabel.height()/2));
+                                            << QLine(MDREMuxTristateLabel.x(),MDREMuxTristateLabel.y()+MDREMuxTristateLabel.height()/2,
+                                                     MDREMuxerDataLabel.right()+25 ,MDREMuxTristateLabel.y()+MDREMuxTristateLabel.height()/2) //Horizontal leg extending from MDROCk
+                                            << QLine(MDREMuxerDataLabel.right()+25,MDREMuxTristateLabel.y()+MDREMuxTristateLabel.height()/2,
+                                                     MDREMuxerDataLabel.right()+25,MDREMuxerDataLabel.y()+MDREMuxerDataLabel.height()/2) //Vertical line segment
+                                            << QLine(MDREMuxerDataLabel.right()+25,MDREMuxerDataLabel.y()+MDREMuxerDataLabel.height()/2,
+                                                     MDREMuxerDataLabel.right()+5,MDREMuxerDataLabel.y()+MDREMuxerDataLabel.height()/2) //Horizonal line segment connecting arrowhead and vertical line
+                                            );
 // EOMux and its control
 const QRect EOMuxerDataLabel        = QRect(MARMuxerDataLabel.x()+MARMuxerDataLabel.width()/2-dataLabelW/2, //Center EOMux horizontally on MARMux
                                             MDREMuxerDataLabel.y()+EOMuxOffsetFromMDREMux, dataLabelW, dataLabelH);
@@ -234,10 +246,9 @@ const QRect EOMuxLabel              = QRect(ctrlLabelX, EOMuxTristateLabel.y(), 
 const Arrow EOMuxSelect             = Arrow(QVector<QPoint>() << QPoint(EOMuxerDataLabel.right()+4,
                                                                         EOMuxTristateLabel.y()+6),
                                             QVector<QLine>()
-                                            << QLine(EOMuxerDataLabel.right()+5, EOMuxTristateLabel.y()+9,
-                                                     326, EOMuxTristateLabel.y()+9)
-                                            << QLine(350, EOMuxTristateLabel.y()+9,
-                                                     ctrlInputX - 7, EOMuxTristateLabel.y()+9));
+                                            <<QLine(EOMuxerDataLabel.right()+5,EOMuxerDataLabel.y()+EOMuxerDataLabel.height()/2,
+                                                    EOMuxTristateLabel.x(),EOMuxerDataLabel.y()+EOMuxerDataLabel.height()/2)
+                                            );
 
 
 // ALU and its control
@@ -339,8 +350,8 @@ const QPolygon EOMuxOutputBus          = QPolygon(QVector<QPoint>()
                                             //Foot
                                             <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2-5,EOMuxerDataLabel.bottom()+1) //Top Left point
                                             <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2+5,EOMuxerDataLabel.bottom()+1) //Top Right point
-                                            <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2+5,EOMuxerDataLabel.bottom()+5) //Point between upper right vertical leg, and upper horizontal leg
-                                            <<QPoint(aMuxerDataLabel.x()+15,EOMuxerDataLabel.bottom()+5) //Point between upper horizontal leg, and the right vertical leg
+                                            <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2+5,EOMuxerDataLabel.bottom()+10) //Point between upper right vertical leg, and upper horizontal leg
+                                            <<QPoint(aMuxerDataLabel.x()+15,EOMuxerDataLabel.bottom()+10) //Point between upper horizontal leg, and the right vertical leg
                                             //Arrow
                                             <<QPoint(aMuxerDataLabel.x()+15,aMuxerDataLabel.y()-(arrowHDepth-5)) //Arrow inner right point
                                             <<QPoint(aMuxerDataLabel.x()+20,aMuxerDataLabel.y()-(arrowHDepth-5)) //Arrow outer right point
@@ -348,8 +359,8 @@ const QPolygon EOMuxOutputBus          = QPolygon(QVector<QPoint>()
                                             <<QPoint(aMuxerDataLabel.x(),aMuxerDataLabel.y()-(arrowHDepth-5)) //Arrow outer left point
                                             <<QPoint(aMuxerDataLabel.x()+5 ,aMuxerDataLabel.y()-(arrowHDepth-5)) //Arrow inner left point
                                             //Remainder of Foot
-                                            <<QPoint(aMuxerDataLabel.x()+5,EOMuxerDataLabel.bottom()+15) //Point between arrow left side and lower horizontal leg
-                                            <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2-5,EOMuxerDataLabel.bottom()+15) //Point between lower horizontal leg and start
+                                            <<QPoint(aMuxerDataLabel.x()+5,EOMuxerDataLabel.bottom()+20) //Point between arrow left side and lower horizontal leg
+                                            <<QPoint(EOMuxerDataLabel.x()+EOMuxerDataLabel.width()/2-5,EOMuxerDataLabel.bottom()+20) //Point between lower horizontal leg and start
                                             );
 
 const QPolygon AMuxBus              = QPolygon(QVector<QPoint>()
@@ -423,16 +434,15 @@ const QPolygon CBus = QPolygon(QVector<QPoint>()
                                <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2+5,cMuxerLabel.y()) //CMux Right foot
                                <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,cMuxerLabel.y()) //CMux Left foot
                                //Branch off to MDREven
-                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+20) //Pivot between CMux foot and MDRE lower Leg
-                               <<QPoint(MDREMuxerDataLabel.right()-15,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+20) //Pivot between MDRE lower leg and MDRE left arrow
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+60) //Pivot between CMux foot and MDRE lower Leg
+                               <<QPoint(MDREMuxerDataLabel.right()-15,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+60) //Pivot between MDRE lower leg and MDRE left arrow
                                <<QPoint(MDREMuxerDataLabel.right()-15,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Left Inner Point
                                <<QPoint(MDREMuxerDataLabel.right()-20,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Left Outer Point
                                <<QPoint(MDREMuxerDataLabel.right()-10,MDREMuxerDataLabel.bottom()+(arrowHOffset)) //MDREMux Arrow Middle Point
                                <<QPoint(MDREMuxerDataLabel.right()-0,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Right Outer Point
                                <<QPoint(MDREMuxerDataLabel.right()-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Right Inner Point
-                               <<QPoint(MDREMuxerDataLabel.right()-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+10) //Pivot between MDRE right arrow and MDRE upper leg
-                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+10) //Pivot between MDRE upper leg and leg upwards
-                               //Resume path to register bank
+                               <<QPoint(MDREMuxerDataLabel.right()-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+50) //Pivot between MDRE right arrow and MDRE upper leg
+                               <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDREMuxerDataLabel.bottom()+(arrowHDepth-5)+50) //Pivot between MDRE upper leg and leg upwards
                                //Branch off to MDROdd
                                <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+20) //Pivot between CMux foot and MDRE lower Leg
                                <<QPoint(MDROMuxerDataLabel.right()-15,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+20) //Pivot between MDRE lower leg and MDRE left arrow
@@ -443,7 +453,7 @@ const QPolygon CBus = QPolygon(QVector<QPoint>()
                                <<QPoint(MDROMuxerDataLabel.right()-5,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)) //MDREMux Arrow Right Inner Point
                                <<QPoint(MDROMuxerDataLabel.right()-5,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+10) //Pivot between MDRE right arrow and MDRE upper leg
                                <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,MDROMuxerDataLabel.bottom()+(arrowHDepth-5)+10) //Pivot between MDRE upper leg and leg upwards
-                               //Resume path to register bank
+                               //Resume path to register bank's arrow
                                <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-5,RegBank.bottom()+(arrowHDepth-5))//Register Arrow Left Inner Point
                                <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2-10,RegBank.bottom()+(arrowHDepth-5))//Register Arrow Left Outer Point
                                <<QPoint(cMuxerLabel.x()+cMuxerLabel.width()/2+0,RegBank.bottom()+(arrowHOffset))//Register Arrow Middle Point


### PR DESCRIPTION
ABC buses are now drawn in the two byte model. Their coloring and positioning is a work in progress.
Moved EOMux upwards 10 pixels, to add some more space between EOMux and AMUX.
Changed literal values in the ALUPolygon to use enumerations instead.
Added painting code for ABC buses, which still needs some polish.
Created buses from MDRE to EOMux and MDRO to EOMux.
Slightly moved ALU down to make more room for busing.
Added necessary painting functions for MDRE and MDRO buses.