### PR TITLE
Microcode Highlighting Fixes & Installer Changes

### DIFF
--- a/config/configlinux.xml
+++ b/config/configlinux.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--Mac version of the config file-->
+<!--Linux version of the config file-->
 <Installer>
     <Name>Pep 9 CPU</Name>
     <Version>1.0.0</Version>
@@ -11,11 +11,11 @@
     <ControlScript>control.qs</ControlScript>
     <InstallerWindowIcon>icon</InstallerWindowIcon>
     <InstallerApplicationIcon>icon</InstallerApplicationIcon>
-    <MaintenanceToolName>Pep 9 Updater and Uninstaller</MaintenanceToolName>
+    <MaintenanceToolName>Pep9Updater</MaintenanceToolName>
     <RemoteRepositories>
         <Repository>
-            <DisplayName>Mac Update Repo</DisplayName>
-            <Url>https://raw.githubusercontent.com/Matthew-McRaven/pep9cpudeploy/master/mac</Url>
+            <DisplayName>Linux Update Repo</DisplayName>
+            <Url>https://raw.githubusercontent.com/Matthew-McRaven/pep9cpudeploy/master/linux</Url>
         </Repository>
 
     </RemoteRepositories>

--- a/config/configwin32.xml
+++ b/config/configwin32.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--Mac version of the config file-->
+<!--Linux version of the config file-->
 <Installer>
     <Name>Pep 9 CPU</Name>
     <Version>1.0.0</Version>
     <Title>Pep 9 CPU Installer</Title>
     <Publisher>Pepperdine University</Publisher>
     <ProductUrl>http://computersystemsbook.com/5th-edition/pep9/</ProductUrl>
-    <TargetDir>@HomeDir@/InstallationDirectory</TargetDir>
+    <TargetDir>@ApplicationsDirX64@/Pep9CPU</TargetDir>
     <Watermark>Pep9cpu-icon.png</Watermark>
     <ControlScript>control.qs</ControlScript>
     <InstallerWindowIcon>icon</InstallerWindowIcon>
     <InstallerApplicationIcon>icon</InstallerApplicationIcon>
-    <MaintenanceToolName>Pep 9 Updater and Uninstaller</MaintenanceToolName>
+    <MaintenanceToolName>Pep9Updater</MaintenanceToolName>
     <RemoteRepositories>
         <Repository>
-            <DisplayName>Mac Update Repo</DisplayName>
+            <DisplayName>Windows Update Repo</DisplayName>
             <Url>https://raw.githubusercontent.com/Matthew-McRaven/pep9cpudeploy/master/win32</Url>
         </Repository>
     </RemoteRepositories>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -31,15 +31,17 @@
 #include <QFileDialog>
 #include <QDesktopServices>
 #include <QUrl>
-
+#include <qtconcurrentrun.h>
 #include <QDebug>
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
-    ui(new Ui::MainWindow)
+    ui(new Ui::MainWindow),updateChecker(new UpdateChecker())
 {
     ui->setupUi(this);
-
+    // connect and begin update checker
+    connect(updateChecker,SIGNAL(updateInformation(int)),this,SLOT(onUpdateCheck(int)));
+    auto x = QtConcurrent::run(updateChecker,&UpdateChecker::beginUpdateCheck);
     // initialize the read-only registers to the correct values
     Sim::initMRegs();
 
@@ -287,6 +289,12 @@ void MainWindow::setCurrentFile(const QString &fileName)
 QString MainWindow::strippedName(const QString &fullFileName)
 {
     return QFileInfo(fullFileName).fileName();
+}
+
+void MainWindow::onUpdateCheck(int val)
+{
+    //Dummy to handle update checking code
+    QMessageBox::information(this,"help","me");
 }
 
 // File MainWindow triggers

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -36,7 +36,7 @@
 #include "sim.h"
 #include "helpdialog.h"
 #include "aboutpep.h"
-
+#include "updatechecker.h"
 #include <QDir>
 
 namespace Ui {
@@ -56,7 +56,7 @@ protected:
 
 private:
     Ui::MainWindow *ui;
-
+    UpdateChecker *updateChecker;
     // Byte converter
     ByteConverterDec *byteConverterDec;
     ByteConverterHex *byteConverterHex;
@@ -89,7 +89,8 @@ private:
     QString curPath;
 
 private slots:
-
+    // Update Check
+    void onUpdateCheck(int val);
     // File
     void on_actionFile_New_triggered();
     void on_actionFile_Open_triggered();
@@ -145,6 +146,7 @@ private slots:
     void updateMemAddress(int address);
 signals:
     void CPUFeaturesChanged();
+    void beginUpdateCheck();
 };
 
 #endif // MAINWINDOW_H

--- a/packages/pep9cpu/installscript.qs
+++ b/packages/pep9cpu/installscript.qs
@@ -1,6 +1,9 @@
 function Component()
 {
     gui.pageWidgetByObjectName("LicenseAgreementPage").entered.connect(changeLicenseLabels);
+    if (installer.value("os") === "win") {
+        component.addOperation("CreateShortcut", "@TargetDir@/MyApp.exe", "@StartMenuDir@/MyApp.lnk");
+    }
     //gui.pageWidgetByObjectName("Introduction").entered.connect(changeLicenseLabels);
 }
 

--- a/pep9cpu.pro
+++ b/pep9cpu.pro
@@ -11,6 +11,7 @@ CONFIG -= debug_and_release \
 QT += webenginewidgets
 QT += widgets
 QT += printsupport
+QT += concurrent
 
 # Mac icon/plist
 ICON = images/icon.icns
@@ -43,7 +44,8 @@ SOURCES += main.cpp \
     specification.cpp \
     byteconverterinstr.cpp \
     aboutpep.cpp \
-    cpugraphicsitems.cpp
+    cpugraphicsitems.cpp \
+    updatechecker.cpp
 HEADERS += mainwindow.h \
     byteconverterhex.h \
     byteconverterdec.h \
@@ -69,7 +71,8 @@ HEADERS += mainwindow.h \
     aboutpep.h \
     cpugraphicsitems.h \
     shapes_one_byte_data_bus.h \
-    shapes_two_byte_data_bus.h
+    shapes_two_byte_data_bus.h \
+    updatechecker.h
 FORMS += mainwindow.ui \
     byteconverterhex.ui \
     byteconverterdec.ui \
@@ -107,8 +110,8 @@ DISTFILES += \
     packages/pep9cpu/installscript.qs \
     packages/pep9cpu/control.qs \
     config/control.qs \
-    config/configmac.xml \
-    config/configwin32.xml
+    config/configwin32.xml \
+    config/configlinux.xml
 
 #Generic paths that make future parts of the code easier
 QtDir = $$clean_path($$[QT_INSTALL_LIBS]/..)
@@ -117,26 +120,26 @@ QtInstallerBin=$$clean_path($$QtDir/../../tools/Qtinstallerframework/3.0/bin)
 #All that needs to be done for mac is to run the DMG creator.
 #The DMG creator will only be run in Release mode, not debug.
 !CONFIG(debug,debug|release):macx{
-#For some reason, the release flag is set in both debug and release.
-#So, the above Config(...) makes it so a disk image is only built in release mode.
+    #For some reason, the release flag is set in both debug and release.
+    #So, the above Config(...) makes it so a disk image is only built in release mode.
 
-#Create necessary directory structure for disk image.
+    #Create necessary directory structure for disk image.
     QMAKE_POST_LINK += $${QMAKE_MKDIR} $$OUT_PWD/Installer;
-#Copy over the executable and bundle it with its dependencies
+    #Copy over the executable and bundle it with its dependencies
     QMAKE_POST_LINK += $${QMAKE_COPY_DIR} $$OUT_PWD/Pep9CPU.app $$OUT_PWD/Installer;
     QMAKE_POST_LINK += $$QtDir/bin/macdeployqt $$OUT_PWD/Installer/Pep9CPU.app -no-plugins;
-#Use HDIUtil to make a folder into a read/write image
+    #Use HDIUtil to make a folder into a read/write image
     QMAKE_POST_LINK += hdiutil create -volname Pep9CPU -srcfolder $$OUT_PWD/Installer -attach -ov -format UDRW Pep9CPUTemp.dmg;
-#Link from the read/write image to the machine's Applications folder
+    #Link from the read/write image to the machine's Applications folder
     QMAKE_POST_LINK += ln -s /Applications /Volumes/Pep9CPU/Applications;
-#Unmount the image, and create a new compressed, readonly image.
+    #Unmount the image, and create a new compressed, readonly image.
     QMAKE_POST_LINK += hdiutil detach /Volumes/Pep9CPU;
     QMAKE_POST_LINK += hdiutil convert -format UDBZ -o Pep9CPU.dmg Pep9CPUTemp.dmg;
-#Remove the temporary read/write image.
+    #Remove the temporary read/write image.
     QMAKE_POST_LINK += $${QMAKE_DEL_FILE} Pep9CPUTemp.dmg;
-#If QMAKE_POST_LINK stops working in a future version, QMAKE provides another way to add custom targets.
-#Use the method described in "Adding Custom Targets" on http://doc.qt.io/qt-5/qmake-advanced-usage.html.
-#Our deployment tool will be called anytime the application is sucessfully linked in release mode.
+    #If QMAKE_POST_LINK stops working in a future version, QMAKE provides another way to add custom targets.
+    #Use the method described in "Adding Custom Targets" on http://doc.qt.io/qt-5/qmake-advanced-usage.html.
+    #Our deployment tool will be called anytime the application is sucessfully linked in release mode.
 }
 
 #Otherwise if the target is windows, but no installer framework exists
@@ -145,7 +148,7 @@ else:!CONFIG(debug,debug|release):win32:!exists(QtInstallerBin/repogen.exe){
     warning("Please run the QT maintence tool and install QT Installer Framework 3.0.")
 }
 
-#Otherwise build the installer for windows as normal.
+    #Otherwise build the installer for windows as normal.
 else:!CONFIG(debug,debug|release):win32{
     repoDir=$$OUT_PWD/Repository/win32
     #Create installer directory structure
@@ -162,6 +165,7 @@ else:!CONFIG(debug,debug|release):win32{
     #Copy over files needed to create installer
     QMAKE_POST_LINK += $${QMAKE_COPY} \"$$shell_path($$PWD\config\configwin32.xml)\" \"$$shell_path($$OUT_PWD/Installer/config/config.xml)\" & \
         $${QMAKE_COPY} \"$$shell_path($$PWD/images/icon.ico)\" \"$$shell_path($$OUT_PWD/Installer/config)\" & \
+        $${QMAKE_COPY} \"$$shell_path($$PWD/images/Pep9cpu-icon.png)\" \"$$shell_path($$OUT_PWD/Installer/config)\" & \
         $${QMAKE_COPY} \"$$shell_path($$PWD/packages/pep9cpu/package.xml)\" \"$$shell_path($$OUT_PWD/Installer/packages/pep9cpu/meta)\" & \
         $${QMAKE_COPY} \"$$shell_path($$PWD/packages/pep9cpu/License.txt)\" \"$$shell_path($$OUT_PWD/Installer/packages/pep9cpu/meta)\" & \
         $${QMAKE_COPY} \"$$shell_path($$PWD/packages/pep9cpu/installscript.qs)\" \"$$shell_path($$OUT_PWD/Installer/packages/pep9cpu/meta)\" & \

--- a/pephighlighter.cpp
+++ b/pephighlighter.cpp
@@ -23,7 +23,7 @@
 #include "pep.h"
 
 PepHighlighter::PepHighlighter(QTextDocument *parent)
-    : QSyntaxHighlighter(parent)
+    : QSyntaxHighlighter(parent),forcedFeatures(false)
 {
     HighlightingRule rule;
 
@@ -88,9 +88,10 @@ void PepHighlighter::forceAllFeatures(bool features)
 {
     forcedFeatures=features;
 }
-
+#include <qdebug>
 void PepHighlighter::highlightBlock(const QString &text)
 {
+
     QVector<HighlightingRule> highlightingRules;
     if(forcedFeatures){
         highlightingRules=highlightingRulesAll;

--- a/updatechecker.cpp
+++ b/updatechecker.cpp
@@ -1,5 +1,5 @@
 #include "updatechecker.h"
-#include <unistd.h>
+//#include <unistd.h>
 UpdateChecker::UpdateChecker(QObject *parent): QObject(parent)
 {
 
@@ -12,6 +12,6 @@ UpdateChecker::~UpdateChecker()
 
 void UpdateChecker::beginUpdateCheck()
 {
-    sleep(2);
-    emit this->updateInformation(5);
+    //sleep(2);
+    //emit this->updateInformation(5);
 }

--- a/updatechecker.cpp
+++ b/updatechecker.cpp
@@ -1,0 +1,17 @@
+#include "updatechecker.h"
+#include <unistd.h>
+UpdateChecker::UpdateChecker(QObject *parent): QObject(parent)
+{
+
+}
+
+UpdateChecker::~UpdateChecker()
+{
+
+}
+
+void UpdateChecker::beginUpdateCheck()
+{
+    sleep(2);
+    emit this->updateInformation(5);
+}

--- a/updatechecker.h
+++ b/updatechecker.h
@@ -1,0 +1,18 @@
+#ifndef UPDATECHECKER_H
+#define UPDATECHECKER_H
+
+#include <QObject>
+#include <QRunnable>
+class UpdateChecker : public QObject
+{
+    Q_OBJECT
+public:
+    explicit UpdateChecker(QObject *parent=nullptr);
+    virtual ~UpdateChecker();
+signals:
+    void updateInformation(int key);
+public slots:
+    void beginUpdateCheck();
+};
+
+#endif // UPDATECHECKER_H


### PR DESCRIPTION
Microcode highlighting should now always choose the correct set of highlighting rules for the one byte or two byte bus.
Added a stub out for an asynchronous update checking utility.
Organized comments in project file.