### PR TITLE
CSMux value no longer overwrites CMux

### DIFF
--- a/cpugraphicsitems.cpp
+++ b/cpugraphicsitems.cpp
@@ -1205,6 +1205,7 @@ void CpuGraphicsItems::paint(QPainter *painter,
     repaintASelect(painter);
     repaintMARCk(painter);
     repaintAMuxSelect(painter); // Needs to be painted before buses
+    repaintCMuxSelect(painter);
     painter->setPen(Qt::black);
 
     switch (Pep::cpuFeatures) {
@@ -1247,7 +1248,6 @@ void CpuGraphicsItems::paint(QPainter *painter,
     }
 
 
-    repaintCMuxSelect(painter);
 
     repaintCSMuxSelect(painter);
 

--- a/cpupane.cpp
+++ b/cpupane.cpp
@@ -1219,7 +1219,7 @@ void CpuPane::on_copyToMicrocodePushButton_clicked() // union of all models
         code.set(Enu::ALU, cpuPaneItems->ALULineEdit->text().toInt());
     }
     if (cpuPaneItems->CSMuxTristateLabel->text() != "") {
-        code.set(Enu::CMux, cpuPaneItems->CSMuxTristateLabel->text().toInt());
+        code.set(Enu::CSMux, cpuPaneItems->CSMuxTristateLabel->text().toInt());
     }
     if (cpuPaneItems->SCkCheckBox->isChecked()) {
         code.set(Enu::SCk, 1);


### PR DESCRIPTION
The value of CSMux no longer ovewrites the value of CMux when using "Copy to Microcode". 
See issue #14 