### PR TITLE
Bug fixes & Installer changes

### DIFF
--- a/cpugraphicsitems.cpp
+++ b/cpugraphicsitems.cpp
@@ -1142,15 +1142,13 @@ CpuGraphicsItems::~CpuGraphicsItems()
 
 QRectF CpuGraphicsItems::boundingRect() const
 {
-    return QRectF(0,0, 650, 620);
-
-
-    if (Pep::cpuFeatures == Enu::TwoByteDataBus) {
-        return QRectF(0,0, 650, 620);
+    if (Pep::cpuFeatures == Enu::OneByteDataBus) {
+        return QRectF(0,0, 650, 670);
     }
     else if (Pep::cpuFeatures == Enu::TwoByteDataBus) {
-        return QRectF(0,0, 650, 620);
+        return QRectF(0,0, 650, TwoByteShapes::BottomOfAlu+TwoByteShapes::MemReadYOffsetFromALU+TwoByteShapes::labelTriH+10);
     }
+    return QRectF(0,0, 650, 670);
 }
 
 bool CpuGraphicsItems::aluHasCorrectOutput()

--- a/cpugraphicsitems.cpp
+++ b/cpugraphicsitems.cpp
@@ -3011,15 +3011,6 @@ void CpuGraphicsItems::repaintBBusTwoByteModel(QPainter *painter)
 
 void CpuGraphicsItems::repaintCBusTwoByteModel(QPainter *painter)
 {
-    bool ok;
-    cLineEdit->text().toInt(&ok, 10);
-    QColor color;
-    color = ok ? combCircuitRed : Qt::white;
-    painter->setPen(QPen(QBrush(Qt::black), 1));
-    painter->setBrush(color);
-
-    // CBus
-    //painter->drawPolygon(TwoByteShapes::CBus);
 }
 
 

--- a/cpugraphicsitems.cpp
+++ b/cpugraphicsitems.cpp
@@ -3019,7 +3019,7 @@ void CpuGraphicsItems::repaintCBusTwoByteModel(QPainter *painter)
     painter->setBrush(color);
 
     // CBus
-    painter->drawPolygon(TwoByteShapes::CBus);
+    //painter->drawPolygon(TwoByteShapes::CBus);
 }
 
 

--- a/cpupane.cpp
+++ b/cpupane.cpp
@@ -57,7 +57,7 @@ CpuPane::CpuPane(CPUType type, QWidget *parent) :
 
     initModel(type);
 
-    ui->spinBox;//->hide();
+    ui->spinBox->hide();
     ui->graphicsView->setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
     ui->singleStepPushButton->setEnabled(false);
     if (type == Enu::TwoByteDataBus) {

--- a/cpupane.cpp
+++ b/cpupane.cpp
@@ -57,9 +57,9 @@ CpuPane::CpuPane(CPUType type, QWidget *parent) :
 
     initModel(type);
 
-    ui->spinBox->hide();
+    ui->spinBox;//->hide();
+    ui->graphicsView->setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
     ui->singleStepPushButton->setEnabled(false);
-
     if (type == Enu::TwoByteDataBus) {
         this->setMaximumWidth(730);
 
@@ -192,12 +192,6 @@ void CpuPane::initModel(Enu::CPUType type)
     connect(cpuPaneItems->EOMuxTristateLabel, SIGNAL(clicked()), scene, SLOT(invalidate()));
     connect(cpuPaneItems->MDRECk, SIGNAL(clicked()), scene, SLOT(invalidate()));
     connect(cpuPaneItems->MDROCk, SIGNAL(clicked()), scene, SLOT(invalidate()));
-
-    // Handle Windows repainting bug
-    // This might have a performance penalty, so only enable it on the platform that needs it.
-#ifdef WIN32
-    connect(ui->graphicsView->verticalScrollBar(),SIGNAL(actionTriggered(int)),this,SLOT(repaintOnScroll(int)));
-#endif
 
 }
 
@@ -1317,12 +1311,6 @@ void CpuPane::ALUTextEdited(QString str)
             break;
         }
     }
-}
-
-void CpuPane::repaintOnScroll(int distance)
-{
-    distance = (int)distance; //Ugly fix to get compiler to silence unused variable warning
-    cpuPaneItems->update();
 }
 
 void CpuPane::run()

--- a/cpupane.h
+++ b/cpupane.h
@@ -101,7 +101,6 @@ protected slots:
     void on_copyToMicrocodePushButton_clicked();
 
     void ALUTextEdited(QString str);
-    void repaintOnScroll(int distance);
 
 public slots:
     void run();

--- a/pep9cpu.pro
+++ b/pep9cpu.pro
@@ -3,7 +3,7 @@
 # -------------------------------------------------
 TEMPLATE = app
 TARGET = Pep9CPU
-
+PEP9_VERSION = 91
 #Prevent Windows from trying to parse the project three times per build.
 CONFIG -= debug_and_release \
     debug_and_release_target
@@ -116,7 +116,7 @@ DISTFILES += \
 #Generic paths that make future parts of the code easier
 QtDir = $$clean_path($$[QT_INSTALL_LIBS]/..)
 QtInstallerBin=$$clean_path($$QtDir/../../tools/Qtinstallerframework/3.0/bin)
-
+OutputInstallerName=Pep9CPU"$$PEP9_VERSION"
 #All that needs to be done for mac is to run the DMG creator.
 #The DMG creator will only be run in Release mode, not debug.
 !CONFIG(debug,debug|release):macx{
@@ -135,7 +135,7 @@ QtInstallerBin=$$clean_path($$QtDir/../../tools/Qtinstallerframework/3.0/bin)
     #Unmount the image, and create a new compressed, readonly image.
     QMAKE_POST_LINK += hdiutil detach /Volumes/Pep9CPU;
     QMAKE_POST_LINK += $${QMAKE_COPY} $$OUT_PWD/Pep9CPUTemp.dmg $$OUT_PWD/Pep9CPUTemp2.dmg;
-    QMAKE_POST_LINK += hdiutil convert -format UDBZ -o $$OUT_PWD/Pep9CPU.dmg $$OUT_PWD/Pep9CPUTemp2.dmg;
+    QMAKE_POST_LINK += hdiutil convert -format UDBZ -o $$OUT_PWD/$$OutputInstallerName"Mac.dmg" $$OUT_PWD/Pep9CPUTemp2.dmg;
     #Remove the temporary read/write image.
     QMAKE_POST_LINK += $${QMAKE_DEL_FILE} $$OUT_PWD/Pep9CPUTemp.dmg;
     QMAKE_POST_LINK += $${QMAKE_DEL_FILE} $$OUT_PWD/Pep9CPUTemp2.dmg;
@@ -179,7 +179,8 @@ else:!CONFIG(debug,debug|release):win32{
     #Execute repository creator
     QMAKE_POST_LINK += \"$$QtInstallerBin/repogen\" --update-new-components -p $$OUT_PWD/Installer/packages $$repoDir &
     #Create installer
-    QMAKE_POST_LINK += \"$$QtInstallerBin/binarycreator\" -c \"$$OUT_PWD/Installer/config/config.xml\" -p \"$$OUT_PWD/Installer/packages\" \"Installer/PEP9CPUInstaller\" &
+    QMAKE_POST_LINK += \"$$QtInstallerBin/binarycreator\" -c \"$$OUT_PWD/Installer/config/config.xml\" -p \"$$OUT_PWD/Installer/packages\" \
+ \"$$OUT_PWD/Installer/$$OutputInstallerName"Win"\" &
 }
 
 #Since there is no native QT deploy tool for Linux, one must be added in the project configuration

--- a/pep9cpu.pro
+++ b/pep9cpu.pro
@@ -127,7 +127,7 @@ QtInstallerBin=$$clean_path($$QtDir/../../tools/Qtinstallerframework/3.0/bin)
     QMAKE_POST_LINK += $${QMAKE_MKDIR} $$OUT_PWD/Installer;
     #Copy over the executable and bundle it with its dependencies
     QMAKE_POST_LINK += $${QMAKE_COPY_DIR} $$OUT_PWD/Pep9CPU.app $$OUT_PWD/Installer;
-    QMAKE_POST_LINK += $$QtDir/bin/macdeployqt $$OUT_PWD/Installer/Pep9CPU.app -no-plugins;
+    QMAKE_POST_LINK += $$QtDir/bin/macdeployqt $$OUT_PWD/Installer/Pep9CPU.app;
     #Use HDIUtil to make a folder into a read/write image
     QMAKE_POST_LINK += hdiutil create -volname Pep9CPU -srcfolder $$OUT_PWD/Installer -attach -ov -format UDRW Pep9CPUTemp.dmg;
     #Link from the read/write image to the machine's Applications folder


### PR DESCRIPTION
Fixed a bug where the mac version would crash on startup after a deploy due to missing dependencies.
Fixed a bug where the size of the two byte diagram wouldn't be respected by the painter due to a bounding rectangle failure.
Fixed a bug where the CBus would be painted twice in the two byte model.
The installer application / disk image should be named correctly
