### PR TITLE
CBus Change & Windows render fix

### DIFF
--- a/cpugraphicsitems.cpp
+++ b/cpugraphicsitems.cpp
@@ -2435,19 +2435,26 @@ void CpuGraphicsItems::repaintBBusOneByteModel(QPainter *painter)
 }
 
 void CpuGraphicsItems::repaintCBusOneByteModel(QPainter *painter)
-{ QColor color;
+{
+    QColor color;
     if (cMuxTristateLabel->text() == "0") {
         color = combCircuitYellow;
+        cMuxerLabel->setPalette(QPalette(muxCircuitYellow));
     }
     else if (cMuxTristateLabel->text() == "1") {
         if (!aluHasCorrectOutput() || ALULineEdit->text() == "15") {
+            // CBus.state == UNDEFINED or NZVC A
+            qDebug() << "WARNING: CMux select: There is no ALU output";
+            cMuxerLabel->setPalette(QPalette(Qt::white));
             color = Qt::white;
         }
         else {
+            cMuxerLabel->setPalette(muxCircuitBlue);
             color = combCircuitBlue;
         }
     }
     else {
+        cMuxerLabel->setPalette(QPalette(Qt::white));
         color = Qt::white;
     }
     painter->setPen(QPen(QBrush(Qt::black), 1));

--- a/cpupane.cpp
+++ b/cpupane.cpp
@@ -193,6 +193,11 @@ void CpuPane::initModel(Enu::CPUType type)
     connect(cpuPaneItems->MDRECk, SIGNAL(clicked()), scene, SLOT(invalidate()));
     connect(cpuPaneItems->MDROCk, SIGNAL(clicked()), scene, SLOT(invalidate()));
 
+    // Handle Windows repainting bug
+    // This might have a performance penalty, so only enable it on the platform that needs it.
+    #ifdef WIN32
+        connect(ui->graphicsView->verticalScrollBar(),SIGNAL(actionTriggered(int)),this,SLOT(repaintOnScroll(int)));
+    #endif
 }
 
 void CpuPane::startDebugging()
@@ -1317,6 +1322,12 @@ void CpuPane::run()
 {
     // Run; these are really equivalent:
     resumeButtonPushed();
+}
+
+void CpuPane::repaintOnScroll(int distance)
+{
+    distance = (int)distance; //Ugly fix to get compiler to silence unused variable warning
+    cpuPaneItems->update();
 }
 
 

--- a/cpupane.h
+++ b/cpupane.h
@@ -104,6 +104,7 @@ protected slots:
 
 public slots:
     void run();
+    void repaintOnScroll(int distance);
 
 signals:
     void updateSimulation();


### PR DESCRIPTION
Fix CBus be painted incorrectly in one byte model
Fixed Windows not rendering two byte bus correctly