### PR TITLE
Selection Fixes

### DIFF
--- a/disableselectionmodel.cpp
+++ b/disableselectionmodel.cpp
@@ -1,0 +1,49 @@
+#include "disableselectionmodel.h"
+#include <qdebug.h>
+#include <QObject>
+#include <QItemSelectionModel>
+
+DisableSelectionModel::DisableSelectionModel(QAbstractItemModel *model):QItemSelectionModel(model),disableSelection(false)
+{
+
+}
+
+DisableSelectionModel::DisableSelectionModel(QAbstractItemModel *model, QObject *parent):QItemSelectionModel(model,parent),disableSelection(false)
+{
+
+}
+
+DisableSelectionModel::~DisableSelectionModel()
+{
+
+}
+
+void DisableSelectionModel::select(const QItemSelection &selection, QItemSelectionModel::SelectionFlags command)
+{
+    if(disableSelection)return;
+    QItemSelectionModel::select(selection,command);
+}
+
+void DisableSelectionModel::select(const QModelIndex &index, QItemSelectionModel::SelectionFlags command)
+{
+    if(disableSelection)return;
+    QItemSelectionModel::select(index,command);
+}
+
+void DisableSelectionModel::forceSelectRow(int row)
+{
+    auto start = this->model()->index(row,0);
+    auto end = model()->index(row,model()->columnCount()-1);
+    clearSelection();
+    QItemSelectionModel::select(QItemSelection(start,end),SelectionFlag::SelectCurrent);
+}
+
+void DisableSelectionModel::onBeginSimulation()
+{
+    disableSelection=true;
+}
+
+void DisableSelectionModel::onEndSimulation()
+{
+    disableSelection=false;
+}

--- a/disableselectionmodel.h
+++ b/disableselectionmodel.h
@@ -1,4 +1,4 @@
-// File: rotatedheaderview.h
+// File: disableselectionmodel.h
 /*
     Pep9CPU is a CPU simulator for executing microcode sequences to
     implement instructions in the instruction set of the Pep/9 computer.
@@ -18,23 +18,26 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef ROTATEDHEADERVIEW_H
-#define ROTATEDHEADERVIEW_H
+#ifndef DISABLESELECTIONMODEL_H
+#define DISABLESELECTIONMODEL_H
 
-#include <QHeaderView>
-#include <QWidget>
 #include <QObject>
-class RotatedHeaderView : public QHeaderView
+#include <QItemSelectionModel>
+#include <QAbstractItemModel>
+class DisableSelectionModel : public QItemSelectionModel
 {
+    bool disableSelection;
     Q_OBJECT
 public:
-    RotatedHeaderView(Qt::Orientation orientation, QWidget *parent = Q_NULLPTR);
-    virtual ~RotatedHeaderView() {};
-protected:
-    void paintSection(QPainter* painter,
-                  const QRect& rect,
-                  int logicalIndex) const override;
-   QSize sectionSizeFromContents(int logicalIndex) const override;
+    DisableSelectionModel(QAbstractItemModel *model = Q_NULLPTR);
+    DisableSelectionModel(QAbstractItemModel *model, QObject *parent);
+    virtual ~DisableSelectionModel();
+    void select(const QItemSelection &selection, QItemSelectionModel::SelectionFlags command) override;
+    void select(const QModelIndex &index, SelectionFlags command) override;
+    void forceSelectRow(int row);
+public slots:
+    void onBeginSimulation();
+    void onEndSimulation();
 };
 
-#endif // ROTATEDHEADERVIEW_H
+#endif // DISABLESELECTIONMODEL_H

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -103,7 +103,9 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(this,SIGNAL(CPUFeaturesChanged()),microcodePane,SLOT(onCPUFeatureChange()));
     connect(this, SIGNAL(CPUFeaturesChanged()),objectCodePane,SLOT(onCPUFeatureChange()));
     //Pep::initEnumMnemonMaps();
-
+    //Connect Simulation events
+    connect(this, SIGNAL(beginSimulation()),this->objectCodePane,SLOT(onBeginSimulation()));
+    connect(this, SIGNAL(endSimulation()),this->objectCodePane,SLOT(onEndSimulation()));
     readSettings();
 
     qApp->installEventFilter(this);
@@ -430,10 +432,10 @@ void MainWindow::on_actionSystem_Run_triggered()
 
 bool MainWindow::on_actionSystem_Start_Debugging_triggered()
 {
+    emit beginSimulation();
     Sim::cycleCount = 0; // this stores the number of cycles in a simulation, reset before assembling
     if (microcodePane->microAssemble()) {
         ui->statusBar->showMessage("MicroAssembly succeeded", 4000);
-#pragma message "fix me"
         objectCodePane->setObjectCode(microcodePane->getMicrocodeProgram());
         bool hasUnitPre = false;
         for (int i = 0; i < Sim::codeList.size(); i++) {
@@ -490,6 +492,7 @@ void MainWindow::on_actionSystem_Stop_Debugging_triggered()
     microcodePane->setReadOnly(false);
 
     cpuPane->stopDebugging();
+    emit endSimulation();
 }
 
 void MainWindow::on_actionSystem_Clear_CPU_triggered()
@@ -780,6 +783,7 @@ void MainWindow::updateSimulation()
 void MainWindow::stopSimulation()
 {
     on_actionSystem_Stop_Debugging_triggered();
+
 }
 
 void MainWindow::simulationFinished()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -147,6 +147,8 @@ private slots:
 signals:
     void CPUFeaturesChanged();
     void beginUpdateCheck();
+    void beginSimulation();
+    void endSimulation();
 };
 
 #endif // MAINWINDOW_H

--- a/objectcodepane.h
+++ b/objectcodepane.h
@@ -23,7 +23,9 @@
 
 #include <QWidget>
 #include <QStandardItemModel>
+#include "disableselectionmodel.h"
 class MicrocodeProgram;
+class RotatedHeaderView;
 namespace Ui {
     class ObjectCodePane;
 }
@@ -32,6 +34,9 @@ class ObjectCodePane : public QWidget {
     Q_OBJECT
     MicrocodeProgram* program;
     quint32 rowCount;
+    RotatedHeaderView* rotatedHeaderView;
+    DisableSelectionModel* selectionModel;
+    QStandardItemModel* model;
     bool inSimulation;
 public:
     ObjectCodePane(QWidget *parent = 0);
@@ -49,10 +54,13 @@ public:
 
     void copy();
     void assignHeaders();
-    bool eventFilter(QObject *object, QEvent *event) override;
-
+signals:
+    void beginSimulation();
+    void endSimulation();
 public slots:
     void onCPUFeatureChange();
+    void onBeginSimulation();
+    void onEndSimulation();
 
 protected:
     void changeEvent(QEvent *e) override;

--- a/objectcodepane.ui
+++ b/objectcodepane.ui
@@ -131,7 +131,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QTableWidget" name="codeTable">
+    <widget class="QTableView" name="codeTable">
      <property name="font">
       <font>
        <family>Courier New</family>
@@ -147,8 +147,8 @@
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
      </property>
-     <attribute name="horizontalHeaderVisible">
-      <bool>false</bool>
+     <attribute name="horizontalHeaderDefaultSectionSize">
+      <number>0</number>
      </attribute>
     </widget>
    </item>

--- a/pep9cpu.pro
+++ b/pep9cpu.pro
@@ -46,7 +46,8 @@ SOURCES += main.cpp \
     cpugraphicsitems.cpp \
     updatechecker.cpp \
     microcodeprogram.cpp \
-    rotatedheaderview.cpp
+    rotatedheaderview.cpp \
+    disableselectionmodel.cpp
 HEADERS += mainwindow.h \
     byteconverterhex.h \
     byteconverterdec.h \
@@ -74,7 +75,8 @@ HEADERS += mainwindow.h \
     shapes_two_byte_data_bus.h \
     updatechecker.h \
     microcodeprogram.h \
-    rotatedheaderview.h
+    rotatedheaderview.h \
+    disableselectionmodel.h
 FORMS += mainwindow.ui \
     byteconverterhex.ui \
     byteconverterdec.ui \


### PR DESCRIPTION
Create a selection model that allows moving of cursor in object code view via code, but prevents key and mouse events from changing the selection.
Added events to propagate knowledge about the state of the simulation (beginning / ending).
Switched table widget to table view, as this allows greater control over the underlying selection and highlighting of object code lines.