### PR TITLE
Font Settings Preserved

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -107,7 +107,8 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(this, SIGNAL(beginSimulation()),this->objectCodePane,SLOT(onBeginSimulation()));
     connect(this, SIGNAL(endSimulation()),this->objectCodePane,SLOT(onEndSimulation()));
     readSettings();
-
+    //Connect font change events
+    connect(this,SIGNAL(defaultFonts()),microcodePane,SLOT(onDefaultFonts()));
     qApp->installEventFilter(this);
 
     connect(cpuPane, SIGNAL(appendMicrocodeLine(QString)), this, SLOT(appendMicrocodeLine(QString)));
@@ -180,12 +181,13 @@ bool MainWindow::eventFilter(QObject *, QEvent *event)
 
 void MainWindow::readSettings()
 {
-    QSettings settings("Pep9CPU", "MainWindow");
+    QSettings settings("cslab.pepperdine","PEP9CPU");
     QDesktopWidget *desktop = QApplication::desktop();
     int width = static_cast<int>(desktop->width() * 0.80);
     int height = static_cast<int>(desktop->height() * 0.70);
     int screenWidth = desktop->width();
     int screenHeight = desktop->height();
+    settings.beginGroup("MainWindow");
     QPoint pos = settings.value("pos", QPoint((screenWidth - width) / 2, (screenHeight - height) / 2)).toPoint();
     QSize size = settings.value("size", QSize(width, height)).toSize();
     if (Pep::getSystem() == "Mac") {
@@ -200,14 +202,21 @@ void MainWindow::readSettings()
     resize(size);
     move(pos);
     curPath = settings.value("filePath", QDir::homePath()).toString();
+    settings.endGroup();
+    //Handle reading for all children
+    microcodePane->readSettings(settings);
 }
 
 void MainWindow::writeSettings()
 {
-    QSettings settings("Pep9CPU", "MainWindow");
+    QSettings settings("cslab.pepperdine","PEP9CPU");
+    settings.beginGroup("MainWindow");
     settings.setValue("pos", pos());
     settings.setValue("size", size());
     settings.setValue("filePath", curPath);
+    settings.endGroup();
+    //Handle writing for all children
+    microcodePane->writeSettings(settings);
 }
 
 // Save methods
@@ -420,6 +429,11 @@ void MainWindow::on_actionEdit_Remove_Error_Messages_triggered()
 void MainWindow::on_actionEdit_Font_triggered()
 {
     microcodePane->setFont();
+}
+
+void MainWindow::on_actionEdit_Reset_font_to_Default_triggered()
+{
+    emit defaultFonts();
 }
 
 // System MainWindow triggers

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -106,6 +106,7 @@ private slots:
     void on_actionEdit_Auto_Format_Microcode_triggered();
     void on_actionEdit_Remove_Error_Messages_triggered();
     void on_actionEdit_Font_triggered();
+    void on_actionEdit_Reset_font_to_Default_triggered();
     // System
     void on_actionSystem_Run_triggered();
     bool on_actionSystem_Start_Debugging_triggered();
@@ -149,6 +150,8 @@ signals:
     void beginUpdateCheck();
     void beginSimulation();
     void endSimulation();
+    //If a sub-compnent wants to be notified that fonts should be restored to their default values, connect to this signal.
+    void defaultFonts();
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -113,6 +113,7 @@
     <addaction name="actionEdit_Remove_Error_Messages"/>
     <addaction name="separator"/>
     <addaction name="actionEdit_Font"/>
+    <addaction name="actionEdit_Reset_font_to_Default"/>
    </widget>
    <widget class="QMenu" name="menuSystem">
     <property name="title">
@@ -539,10 +540,22 @@
     <string>Ctrl+2</string>
    </property>
   </action>
+  <action name="actionEdit_Reset_font_to_Default">
+   <property name="text">
+    <string>Reset Font to Default</string>
+   </property>
+   <property name="toolTip">
+    <string>Reset Font to Default</string>
+   </property>
+  </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <resources>
   <include location="pep9cpuresources.qrc"/>
  </resources>
  <connections/>
+ <slots>
+  <signal>defaultFonts()</signal>
+  <slot>on_actionEdit_Font_Default_triggered()</slot>
+ </slots>
 </ui>

--- a/microcodeeditor.cpp
+++ b/microcodeeditor.cpp
@@ -22,6 +22,7 @@
 #include <QtGui>
 
 #include "microcodeeditor.h"
+#include "pep.h"
 
 #include <QDebug>
 
@@ -250,6 +251,27 @@ void MicrocodeEditor::unCommentSelection()
     setTextCursor(cursor);
 
     cursor.endEditBlock();
+}
+
+void MicrocodeEditor::readSettings(QSettings &settings)
+{
+    settings.beginGroup("MicrocodeEditor");
+    QFont font=QFont(Pep::cpuFont,Pep::codeFontSize); //Pick a default font if the config file is unreadable.
+    QVariant val = settings.value("EditorFont");
+    if(val.canConvert<QFont>())
+    {
+        font= qvariant_cast<QFont>(val);
+    }
+    setFont(font);
+    settings.endGroup();
+}
+
+void MicrocodeEditor::writeSettings(QSettings &settings)
+{
+    settings.beginGroup("MicrocodeEditor");
+    QVariant var = QVariant(font());
+    settings.setValue("EditorFont",font());
+    settings.endGroup();
 }
 
 void MicrocodeEditor::resizeEvent(QResizeEvent *e)

--- a/microcodeeditor.h
+++ b/microcodeeditor.h
@@ -47,7 +47,8 @@ public:
     void clearSimulationView();
 
     void unCommentSelection();
-
+    void readSettings(QSettings& settings);
+    void writeSettings(QSettings& settings);
 protected:
     void resizeEvent(QResizeEvent *event);
 

--- a/microcodepane.cpp
+++ b/microcodepane.cpp
@@ -283,9 +283,28 @@ void MicrocodePane::setFilename(QString fileName)
     }
 }
 
+void MicrocodePane::readSettings(QSettings &settings)
+{
+    settings.beginGroup("MicrocodePane");
+    editor->readSettings(settings);
+    settings.endGroup();
+}
+
+void MicrocodePane::writeSettings(QSettings &settings)
+{
+    settings.beginGroup("MicrocodePane");
+    editor->writeSettings(settings);
+    settings.endGroup();
+}
+
 void MicrocodePane::onCPUFeatureChange()
 {
     highlighter->rehighlight();
+}
+
+void MicrocodePane::onDefaultFonts()
+{
+    editor->setFont(QFont(Pep::cpuFont,Pep::codeFontSize));
 }
 
 void MicrocodePane::setLabelToModified(bool modified)

--- a/microcodepane.h
+++ b/microcodepane.h
@@ -88,8 +88,11 @@ public:
     void unCommentSelection();
 
     void setFilename(QString fileName);
+    void readSettings(QSettings &settings);
+    void writeSettings(QSettings &settings);
 public slots:
     void onCPUFeatureChange();
+    void onDefaultFonts();
 protected:
     void changeEvent(QEvent *e);
 

--- a/objectcodepane.cpp
+++ b/objectcodepane.cpp
@@ -108,6 +108,7 @@ void ObjectCodePane::setObjectCode(MicrocodeProgram* program)
             if(x!="-1")
             {
                 auto y =new QStandardItem(x);
+                y->setTextAlignment(Qt::AlignCenter);
                 //Ownership of y is taken by the codeTable, so no need to deal with the pointer ourselves
                 model->setItem(rowNum,colNum,y);
             }

--- a/rotatedheaderview.cpp
+++ b/rotatedheaderview.cpp
@@ -11,7 +11,7 @@ void RotatedHeaderView::paintSection(QPainter *painter, const QRect &rect, int l
     painter->save();
     qreal angle=-90;
     qint32 nx=-rect.bottom(),
-            ny=rect.x()+rect.width()/4; //Frankly, I'm not sure why 4 looks the best, but it does
+            ny=rect.x()+rect.width()/2-5; //Frankly, I'm not sure why 4 looks the best, but it does
     QRect nRect = QRect(nx,ny,rect.height(),rect.width());
     painter->rotate(angle);
     painter->drawText(nRect,this->model()->headerData(logicalIndex,Qt::Horizontal).toString());


### PR DESCRIPTION
Changes made to the microcode pane's font will be preserved between runs.
Added a signal in the MainWindow that can notify sub-objects if they should reset to default fonts.
Re-structured settings file, so that all window components would use a single file.