### PR TITLE
Bump to version 9.2 & unify Pep9CPU fonts.

### DIFF
--- a/aboutpep.ui
+++ b/aboutpep.ui
@@ -109,9 +109,8 @@
          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Verdana'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt; font-weight:600;&quot;&gt;Pep/9 CPU version 9.1&lt;/span&gt;&lt;/p&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Verdana'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt; font-weight:600;&quot;&gt;Pep/9 CPU version 9.2&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:11pt; font-weight:600;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://computersystemsbook.com/5th-edition/pep9/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Check for updates&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
@@ -152,7 +151,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.SF NS Text'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:16pt; font-weight:600;&quot;&gt;Pep/9 CPU version 9.1&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:16pt; font-weight:600;&quot;&gt;Pep/9 CPU version 9.2&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Lucida Grande'; font-size:16pt; font-weight:600;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://computersystemsbook.com/5th-edition/pep9/&quot;&gt;&lt;span style=&quot; font-family:'Lucida Grande'; text-decoration: underline; color:#0000ff;&quot;&gt;Check for updates&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'Lucida Grande'; font-size:14pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;

--- a/helpdialog.cpp
+++ b/helpdialog.cpp
@@ -114,6 +114,11 @@ void HelpDialog::changeEvent(QEvent *e)
     }
 }
 
+void HelpDialog::onFontChanged(QFont font)
+{
+    microcodeEditor->setFont(font);
+}
+
 void HelpDialog::onCurrentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*) {
     // Is this a subcategory?
     bool isHelpSubCat = ui->helpTreeWidget->currentIndex().parent().isValid();

--- a/helpdialog.h
+++ b/helpdialog.h
@@ -139,6 +139,8 @@ private:
         ePR1236F = 19,
     };
 
+public slots:
+    void onFontChanged(QFont font);
 private slots:
     void onCurrentItemChanged(QTreeWidgetItem*,QTreeWidgetItem*);
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -56,6 +56,7 @@ protected:
 
 private:
     Ui::MainWindow *ui;
+    QFont codeFont;
     UpdateChecker *updateChecker;
     // Byte converter
     ByteConverterDec *byteConverterDec;
@@ -151,7 +152,7 @@ signals:
     void beginSimulation();
     void endSimulation();
     //If a sub-compnent wants to be notified that fonts should be restored to their default values, connect to this signal.
-    void defaultFonts();
+    void fontChanged(QFont font);
 };
 
 #endif // MAINWINDOW_H

--- a/microcodeeditor.cpp
+++ b/microcodeeditor.cpp
@@ -28,7 +28,6 @@
 
 MicrocodeEditor::MicrocodeEditor(QWidget *parent, bool highlightCurrentLine, bool isReadOnly) : QPlainTextEdit(parent)
 {
-    setFont(QFont("Courier"));
 
     highlightCurLine = highlightCurrentLine;
 
@@ -256,21 +255,12 @@ void MicrocodeEditor::unCommentSelection()
 void MicrocodeEditor::readSettings(QSettings &settings)
 {
     settings.beginGroup("MicrocodeEditor");
-    QFont font=QFont(Pep::cpuFont,Pep::codeFontSize); //Pick a default font if the config file is unreadable.
-    QVariant val = settings.value("EditorFont");
-    if(val.canConvert<QFont>())
-    {
-        font= qvariant_cast<QFont>(val);
-    }
-    setFont(font);
     settings.endGroup();
 }
 
 void MicrocodeEditor::writeSettings(QSettings &settings)
 {
     settings.beginGroup("MicrocodeEditor");
-    QVariant var = QVariant(font());
-    settings.setValue("EditorFont",font());
     settings.endGroup();
 }
 

--- a/microcodepane.cpp
+++ b/microcodepane.cpp
@@ -239,15 +239,6 @@ void MicrocodePane::setReadOnly(bool ro)
     editor->setReadOnly(ro);
 }
 
-void MicrocodePane::setFont()
-{
-    bool ok = false;
-    QFont font = QFontDialog::getFont(&ok, QFont(editor->font()), this, "Set Source Code Font");
-    if (ok) {
-        editor->setFont(font);
-    }
-}
-
 bool MicrocodePane::isModified()
 {
     return editor->document()->isModified();
@@ -302,10 +293,11 @@ void MicrocodePane::onCPUFeatureChange()
     highlighter->rehighlight();
 }
 
-void MicrocodePane::onDefaultFonts()
+void MicrocodePane::onFontChanged(QFont font)
 {
-    editor->setFont(QFont(Pep::cpuFont,Pep::codeFontSize));
+    editor->setFont(font);
 }
+
 
 void MicrocodePane::setLabelToModified(bool modified)
 {

--- a/microcodepane.h
+++ b/microcodepane.h
@@ -75,8 +75,6 @@ public:
     bool isUndoable();
     bool isRedoable();
 
-    void setFont();
-
     void setReadOnly(bool ro);
 
     bool isModified();
@@ -92,7 +90,7 @@ public:
     void writeSettings(QSettings &settings);
 public slots:
     void onCPUFeatureChange();
-    void onDefaultFonts();
+    void onFontChanged(QFont font);
 protected:
     void changeEvent(QEvent *e);
 

--- a/packages/pep9cpu/package.xml
+++ b/packages/pep9cpu/package.xml
@@ -2,7 +2,7 @@
 <Package>
     <DisplayName>Pep 9 CPU</DisplayName>
     <Description>This is the Pep9 CPU!</Description>
-    <Version>9.1.0</Version>
+    <Version>9.2.0</Version>
     <ReleaseDate>2018-02-18</ReleaseDate>
     <Licenses>
         <License name="GNU GENERAL PUBLIC LICENSE" file="License.txt" />

--- a/pep9cpu.pro
+++ b/pep9cpu.pro
@@ -3,7 +3,7 @@
 # -------------------------------------------------
 TEMPLATE = app
 TARGET = Pep9CPU
-PEP9_VERSION = 91
+PEP9_VERSION = 92
 #Prevent Windows from trying to parse the project three times per build.
 CONFIG -= debug_and_release \
     debug_and_release_target


### PR DESCRIPTION
Both the help dialog and microcode pane now share a font. If the font is changed via edit->font..., both will be updated to reflect the change.
Changed version number from 9.1 to 9.2, to reflect the significant re-addition of the object code pane.