### PR TITLE
Microcode editor fixes & readability improvements

### DIFF
--- a/colors.cpp
+++ b/colors.cpp
@@ -7,7 +7,6 @@ const PepColors::Colors PepColors::initDark()
     retVal.comment = QColor(Qt::green).lighter();
     retVal.leftOfExpression = QColor("lightsteelblue");
     retVal.rightOfExpression = QColor(Qt::red).lighter();
-    retVal.memoryHighlight = QColor("lightgreen").darker(130);
 
     retVal.seqCircuitColor= QColor(0x3B3630).lighter(200); //Used to be 370 0x3B3630
     retVal.combCircuitRed = QColor(0xDF5A49);
@@ -17,15 +16,23 @@ const PepColors::Colors PepColors::initDark()
 
     retVal.muxCircuitRed = retVal.combCircuitRed.darker(110); // A sightly lighter shade of combCircuitRed that is a better background for text
     retVal.muxCircuitBlue = retVal.combCircuitBlue.darker(110); // A sightly lighter shade of combCircuitBlue that is a better background for text
-    retVal.aluColor = retVal.combCircuitBlue;
-    retVal.aluOutline = retVal.combCircuitBlue.lighter(140);
     retVal.muxCircuitYellow = retVal.combCircuitYellow.darker(110); // A sightly lighter shade of combCircuitYellow that is a better background for text
     retVal.muxCircuitGreen = retVal.combCircuitGreen.darker(110); // A sightly lighter shade of combCircuitGreen that is a better background for text
+
+    retVal.aluColor = retVal.combCircuitBlue;
+    retVal.aluOutline = retVal.combCircuitBlue.lighter(140);
+
     retVal.arrowColorOn = QColor(0xeeeeee); //Used to be Qt::white
     retVal.arrowColorOff = QColor(Qt::gray); //Used to be Qt:gray
     retVal.backgroundFill= QColor(0x31363b);
     retVal.arrowImageOn=(":/images/arrowhead_dark.png");
     retVal.arrowImageOff=(":/images/arrowhead_gray.png");
+
+    retVal.memoryHighlight = retVal.muxCircuitGreen;
+    retVal.lineAreaBackground = retVal.backgroundFill;
+    retVal.lineAreaText = PepColors::invert(retVal.lineAreaBackground).lighter(130);
+    retVal.lineAreaHighlight = QColor(Qt::red).darker(170);
+
     return retVal;
 }
 
@@ -35,25 +42,37 @@ const PepColors::Colors PepColors::initLight()
     retVal.comment = Qt::darkGreen;
     retVal.leftOfExpression = Qt::darkBlue;
     retVal.rightOfExpression = Qt::darkMagenta;
-    retVal.memoryHighlight = QColor("green");
 
     retVal.seqCircuitColor= QColor(0x3B3630).lighter(370);
     retVal.combCircuitRed = QColor(0xD92405).lighter(140);
-    retVal.muxCircuitRed = retVal.combCircuitRed.lighter(140); // A sightly lighter shade of combCircuitRed that is a better background for text
     retVal.combCircuitBlue = QColor(0x3563EB).lighter(120);
+    retVal.combCircuitYellow = QColor(0xEAC124).lighter(120);
+    retVal.combCircuitGreen = QColor(0x739211).lighter(130);
+
+    retVal.muxCircuitRed = retVal.combCircuitRed.lighter(140); // A sightly lighter shade of combCircuitRed that is a better background for text
     retVal.muxCircuitBlue = retVal.combCircuitBlue.lighter(140); // A sightly lighter shade of combCircuitBlue that is a better background for text
+    retVal.muxCircuitYellow = retVal.combCircuitYellow.lighter(140); // A sightly lighter shade of combCircuitYellow that is a better background for text
+    retVal.muxCircuitGreen = retVal.combCircuitGreen.lighter(140); // A sightly lighter shade of combCircuitGreen that is a better background for text
+
     retVal.aluColor = retVal.combCircuitBlue.lighter(140);
     retVal.aluOutline = retVal.combCircuitBlue;
 
-    retVal.combCircuitYellow = QColor(0xEAC124).lighter(120);
-    retVal.muxCircuitYellow = retVal.combCircuitYellow.lighter(140); // A sightly lighter shade of combCircuitYellow that is a better background for text
-    retVal.combCircuitGreen = QColor(0x739211).lighter(130);
-    retVal.muxCircuitGreen = retVal.combCircuitGreen.lighter(140); // A sightly lighter shade of combCircuitGreen that is a better background for text
     retVal.arrowColorOn = Qt::black;
     retVal.arrowColorOff = Qt::gray;
     retVal.backgroundFill= QColor(Qt::white);
     retVal.arrowImageOn=(":/images/arrowhead.png");
     retVal.arrowImageOff=(":/images/arrowhead_gray.png");
+
+    retVal.memoryHighlight = retVal.muxCircuitGreen;
+    retVal.lineAreaBackground = retVal.backgroundFill;
+    retVal.lineAreaText = PepColors::invert(retVal.lineAreaBackground);
+    retVal.lineAreaHighlight = QColor(Qt::red).lighter(170);
+
     return retVal;
 }
 
+
+QColor PepColors::invert(QColor input)
+{
+    return QColor(255-input.red(),255-input.green(),255-input.blue(),input.alpha());
+}

--- a/colors.h
+++ b/colors.h
@@ -8,7 +8,6 @@ namespace PepColors{
         QColor comment;
         QColor rightOfExpression;
         QColor leftOfExpression;
-        QColor memoryHighlight;
 
         QColor seqCircuitColor;
         QColor combCircuitRed;
@@ -26,11 +25,17 @@ namespace PepColors{
         QColor backgroundFill;
         QString arrowImageOn;
         QString arrowImageOff;
+
+        QColor memoryHighlight;
+        QColor lineAreaBackground;
+        QColor lineAreaText;
+        QColor lineAreaHighlight;
     };
     static const QColor transparent = QColor(255,255,255,0);
     const Colors initLight();
     const Colors initDark();
     static const Colors lightMode = {initLight()};
     static const Colors darkMode = {initDark()};
+    QColor invert(QColor input);
 }
 #endif // COLORS_H

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -121,6 +121,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(this, &MainWindow::darkModeChanged, cpuPaneTwoByteDataBus, &CpuPane::onDarkModeChanged);
     connect(this, &MainWindow::darkModeChanged, cpuPaneOneByteDataBus, &CpuPane::onDarkModeChanged);
     connect(this, &MainWindow::darkModeChanged, mainMemory, &MainMemory::onDarkModeChange);
+    connect(this, &MainWindow::darkModeChanged, microcodePane->getEditor(), &MicrocodeEditor::onDarkModeChanged);
     qApp->installEventFilter(this);
     //Load Style sheets
     QFile f(":qdarkstyle/dark_style.qss");
@@ -870,7 +871,8 @@ void MainWindow::helpCopyToMicrocodeButtonClicked()
         }
 
         microcodePane->setMicrocode(helpDialog->getExampleText());
-        objectCodePane->setObjectCode();
+        microcodePane->microAssemble();
+        objectCodePane->setObjectCode(microcodePane->getMicrocodeProgram());
         helpDialog->hide();
         statusBar()->showMessage("Copied to microcode", 4000);
     }

--- a/microcodeeditor.cpp
+++ b/microcodeeditor.cpp
@@ -27,7 +27,7 @@
 #include "microcodeprogram.h"
 #include <QDebug>
 
-MicrocodeEditor::MicrocodeEditor(QWidget *parent, bool highlightCurrentLine, bool isReadOnly) : QPlainTextEdit(parent)
+MicrocodeEditor::MicrocodeEditor(QWidget *parent, bool highlightCurrentLine, bool isReadOnly) : QPlainTextEdit(parent), colors(&PepColors::lightMode)
 {
 
     highlightCurLine = highlightCurrentLine;
@@ -266,6 +266,12 @@ void MicrocodeEditor::writeSettings(QSettings &settings)
     settings.endGroup();
 }
 
+void MicrocodeEditor::onDarkModeChanged(bool darkMode)
+{
+    if(darkMode)colors = &PepColors::darkMode;
+    else colors = &PepColors::lightMode;
+}
+
 void MicrocodeEditor::resizeEvent(QResizeEvent *e)
 {
     QPlainTextEdit::resizeEvent(e);
@@ -277,7 +283,7 @@ void MicrocodeEditor::resizeEvent(QResizeEvent *e)
 void MicrocodeEditor::lineNumberAreaPaintEvent(QPaintEvent *event)
 {
     QPainter painter(lineNumberArea);
-    painter.fillRect(event->rect(), QColor(232, 232, 232)); // light grey
+    painter.fillRect(event->rect(),colors->backgroundFill); // light grey
     QTextBlock block;
     int blockNumber;
     int top;
@@ -297,7 +303,7 @@ void MicrocodeEditor::lineNumberAreaPaintEvent(QPaintEvent *event)
         }
         if (block.isValid()) {
             painter.setPen(QColor(232, 232, 232));
-            painter.setBrush(QBrush(QColor(Qt::red).lighter(170)));
+            painter.setBrush(colors->lineAreaHighlight);
             painter.drawRect(-1, top, lineNumberArea->width(), fontMetrics().height());
         }
     }
@@ -321,7 +327,7 @@ void MicrocodeEditor::lineNumberAreaPaintEvent(QPaintEvent *event)
     while (block.isValid() && top <= event->rect().bottom()) {
         if (block.isVisible() && bottom >= event->rect().top()) {
             QString number = blockToCycleNumber.at(blockNumber) == -1 ? QString("") : QString::number(blockToCycleNumber.at(blockNumber));
-            painter.setPen(QColor(128, 128, 130)); // grey
+            painter.setPen(colors->lineAreaText); // grey
             painter.setFont(QFont(Pep::codeFont,Pep::codeFontSize));
             painter.drawText(-1, top, lineNumberArea->width(), fontMetrics().height(), Qt::AlignRight, number);
         }

--- a/microcodeeditor.h
+++ b/microcodeeditor.h
@@ -23,7 +23,7 @@
 
 #include <QPlainTextEdit>
 #include <QObject>
-
+#include "colors.h"
 class QPaintEvent;
 class QResizeEvent;
 class QSize;
@@ -48,6 +48,9 @@ public:
     void unCommentSelection();
     void readSettings(QSettings& settings);
     void writeSettings(QSettings& settings);
+
+public slots:
+    void onDarkModeChanged(bool darkMode);
 protected:
     void resizeEvent(QResizeEvent *event);
 
@@ -59,7 +62,7 @@ private:
     QWidget *lineNumberArea;
 
     bool highlightCurLine;
-
+    const PepColors::Colors *colors;
     int getMicrocodeBlockNumbers();
 };
 

--- a/microcodepane.cpp
+++ b/microcodepane.cpp
@@ -180,7 +180,6 @@ void MicrocodePane::setMicrocode(QString microcode)
     }
     microcode = sourceCodeList.join("\n");
     editor->setPlainText(microcode);
-
     setLabelToModified(true);
 }
 
@@ -291,6 +290,11 @@ void MicrocodePane::writeSettings(QSettings &settings)
     settings.beginGroup("MicrocodePane");
     editor->writeSettings(settings);
     settings.endGroup();
+}
+
+MicrocodeEditor *MicrocodePane::getEditor()
+{
+    return editor;
 }
 
 void MicrocodePane::onCPUFeatureChange()

--- a/microcodepane.h
+++ b/microcodepane.h
@@ -88,6 +88,7 @@ public:
     void setFilename(QString fileName);
     void readSettings(QSettings &settings);
     void writeSettings(QSettings &settings);
+    MicrocodeEditor* getEditor();
 public slots:
     void onCPUFeatureChange();
     void onFontChanged(QFont font);

--- a/objectcodepane.cpp
+++ b/objectcodepane.cpp
@@ -47,6 +47,7 @@ ObjectCodePane::ObjectCodePane(QWidget *parent) :
     ui->codeTable->setSelectionModel(selectionModel);
     ui->codeTable->setHorizontalHeader(rotatedHeaderView);
     ui->codeTable->setFont(font);
+    ui->codeTable->verticalHeader()->setDefaultAlignment(Qt::AlignRight|Qt::AlignJustify);
     ui->codeTable->verticalHeader()->setDefaultSectionSize(12);
     ui->codeTable->horizontalHeader()->setDefaultSectionSize(15);
     ui->codeTable->setShowGrid(false);


### PR DESCRIPTION
When copying a built in program to the source pane, the object code will automatically fill in.
The line numbers area to the right of the source pane are now configurable programmatically from colors.cpp.
The line number area now responds to dark mode.
The line numbers of the object code pane now are right justified.